### PR TITLE
chore: Add MetadataService for managing entity metadata

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ type Client struct {
 	Identity       *IdentityService
 	Search         *SearchService
 	Reconciliation *ReconciliationService
+	Metadata       *MetadataService
 }
 
 // create a client interface
@@ -94,6 +95,7 @@ func NewClient(baseURL *url.URL, apiKey *string, opts ...ClientOption) *Client {
 	client.Identity = &IdentityService{client: client}
 	client.Search = &SearchService{client: client}
 	client.Reconciliation = &ReconciliationService{client: client}
+	client.Metadata = &MetadataService{client: client}
 
 	return client
 }

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,41 @@
+package blnkgo
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type MetadataService service
+
+type UpdateMetaDataRequest struct {
+	MetaData map[string]interface{} `json:"meta_data"`
+}
+
+type Metadata struct {
+	MetaData map[string]interface{} `json:"metadata"`
+}
+
+func (s *MetadataService) UpdateMetadata(entityID string, body UpdateMetaDataRequest) (*Metadata, *http.Response, error) {
+	if entityID == "" {
+		return nil, nil, fmt.Errorf("entity ID is required")
+	}
+
+	u := fmt.Sprintf("%s/metadata", entityID)
+
+	req, err := s.client.NewRequest(u, http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response := new(Metadata)
+	resp, err := s.client.CallWithRetry(req, response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response, resp, nil
+}
+
+func NewMetadataService(client ClientInterface) *MetadataService {
+	return &MetadataService{client: client}
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,143 @@
+package blnkgo_test
+
+import (
+	"errors"
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"testing"
+)
+
+// Helper function to setup mock client and service
+func setupMetdataService() (*MockClient, *blnkgo.MetadataService) {
+	mockClient := &MockClient{}
+	svc := blnkgo.NewMetadataService(mockClient)
+	return mockClient, svc
+}
+
+func TestTransactionService_UpdateMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		entityID    string
+		metadata    map[string]interface{}
+		expectError bool
+		errorMsg    string
+		statusCode  int
+		setupMocks  func(*MockClient)
+	}{
+		{
+			name:     "successful metadata update",
+			entityID: "entity-123",
+			metadata: map[string]interface{}{
+				"key1": "value1",
+				"key2": 42,
+				"key3": true,
+			},
+			expectError: false,
+			statusCode:  http.StatusOK,
+			setupMocks: func(m *MockClient) {
+				expectedResponse := &blnkgo.UpdateMetaDataRequest{
+					MetaData: map[string]interface{}{
+						"key1": "value1",
+						"key2": 42,
+						"key3": true,
+					},
+				}
+
+				m.On("NewRequest", "entity-123/metadata", http.MethodPost,
+					mock.MatchedBy(func(req blnkgo.UpdateMetaDataRequest) bool {
+						return assert.ObjectsAreEqual(req.MetaData, expectedResponse.MetaData)
+					})).Return(&http.Request{}, nil)
+
+				m.On("CallWithRetry", mock.Anything, mock.Anything).
+					Return(&http.Response{StatusCode: http.StatusOK}, nil).
+					Run(func(args mock.Arguments) {
+						response := args.Get(1).(*blnkgo.Metadata)
+						*response = blnkgo.Metadata(*expectedResponse)
+					})
+			},
+		},
+		{
+			name:        "empty entity ID",
+			entityID:    "",
+			metadata:    map[string]interface{}{"key": "value"},
+			expectError: true,
+			errorMsg:    "entity ID is required",
+			setupMocks:  func(m *MockClient) {},
+		},
+		{
+			name:        "request creation failure",
+			entityID:    "entity-123",
+			metadata:    map[string]interface{}{"key": "value"},
+			expectError: true,
+			errorMsg:    "failed to create request",
+			setupMocks: func(m *MockClient) {
+				m.On("NewRequest", "entity-123/metadata", http.MethodPost, mock.Anything).
+					Return(nil, errors.New("failed to create request"))
+			},
+		},
+		{
+			name:        "server error",
+			entityID:    "entity-123",
+			metadata:    map[string]interface{}{"key": "value"},
+			expectError: true,
+			errorMsg:    "server error",
+			statusCode:  http.StatusInternalServerError,
+			setupMocks: func(m *MockClient) {
+				m.On("NewRequest", "entity-123/metadata", http.MethodPost, mock.Anything).
+					Return(&http.Request{}, nil)
+				m.On("CallWithRetry", mock.Anything, mock.Anything).
+					Return(&http.Response{StatusCode: http.StatusInternalServerError},
+						errors.New("server error"))
+			},
+		},
+		{
+			name:        "entity not found",
+			entityID:    "nonexistent-123",
+			metadata:    map[string]interface{}{"key": "value"},
+			expectError: true,
+			errorMsg:    "entity not found",
+			statusCode:  http.StatusNotFound,
+			setupMocks: func(m *MockClient) {
+				m.On("NewRequest", "nonexistent-123/metadata", http.MethodPost, mock.Anything).
+					Return(&http.Request{}, nil)
+				m.On("CallWithRetry", mock.Anything, mock.Anything).
+					Return(&http.Response{StatusCode: http.StatusNotFound},
+						errors.New("entity not found"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient, svc := setupMetdataService()
+			tt.setupMocks(mockClient)
+
+			response, resp, err := svc.UpdateMetadata(tt.entityID, blnkgo.UpdateMetaDataRequest{MetaData: tt.metadata})
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+				if tt.entityID == "" {
+					assert.Nil(t, resp)
+					mockClient.AssertNotCalled(t, "NewRequest")
+					mockClient.AssertNotCalled(t, "CallWithRetry")
+				} else if tt.name == "request creation failure" {
+					assert.Nil(t, response)
+					assert.Nil(t, resp)
+					mockClient.AssertNotCalled(t, "CallWithRetry")
+				} else {
+					assert.Equal(t, tt.statusCode, resp.StatusCode)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, response)
+				assert.NotNil(t, resp)
+				assert.Equal(t, tt.statusCode, resp.StatusCode)
+				assert.Equal(t, tt.metadata, response.MetaData)
+			}
+			mockClient.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
- Introduced `MetadataService` to support metadata updates for entities. 
- Included request creation, server communication, and error handling. 
- Added comprehensive unit tests to validate functionality under various scenarios.