### PR TITLE
feat: Add amount field to UpdateStatus for transaction updates

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -49,6 +49,7 @@ type Transaction struct {
 
 type UpdateStatus struct {
 	Status InflightStatus `json:"status"`
+	Amount float64        `json:"amount"`
 }
 
 func (s *TransactionService) Create(body CreateTransactionRequest) (*Transaction, *http.Response, error) {


### PR DESCRIPTION
This pull request includes a change to the `Transaction` struct in the `transaction.go` file to add a new field for the transaction amount.

* [`transaction.go`](diffhunk://#diff-63ab601287b8b9c040760fe0bdd288f55b73f37cd7e4f1e519bea2bd43a18bbaR52): Added a new `Amount` field of type `float64` to the `UpdateStatus` struct.