### PR TITLE
fix: Update regex for percentage and number validation

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -8,8 +8,8 @@ import (
 type Distribution string
 
 var (
-	percentageRegex = regexp.MustCompile(`^\d+%$`)
-	numberRegex     = regexp.MustCompile(`^\d+$`)
+	percentageRegex = regexp.MustCompile(`^\d+(\.\d+)?%$`)
+	numberRegex     = regexp.MustCompile(`^\d+(\.\d+)?$`)
 )
 
 func (d Distribution) IsValid() bool {

--- a/examples/multi-sources/main.go
+++ b/examples/multi-sources/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+)
+
+func main() {
+	baseURL, _ := url.Parse("http://localhost:5001/")
+	client := blnkgo.NewClient(baseURL, nil, blnkgo.WithTimeout(
+		5*time.Second,
+	), blnkgo.WithRetry(2))
+
+	_, _, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      1000,
+			Reference:   "ref-21d",
+			Precision:   100,
+			Currency:    "USD",
+			Description: "Alice Funds",
+			Destination: "@alice",
+			Sources: []blnkgo.Source{
+				{
+					Identifier:   "@test-1",
+					Distribution: "5.500000%",
+				},
+				{
+					Identifier:   "@test-2",
+					Distribution: "left",
+				},
+			},
+		},
+	})
+	fmt.Println(err)
+}

--- a/transaction.go
+++ b/transaction.go
@@ -27,7 +27,7 @@ type ParentTransaction struct {
 	Rate          float64                `json:"rate,omitempty"`
 	Source        string                 `json:"source,omitempty"`
 	Destination   string                 `json:"destination,omitempty"`
-	PreciseAmount int64                  `json:"precise_amount"`
+	PreciseAmount int64                  `json:"precise_amount,omitempty"`
 	SkipQueue     bool                   `json:"skip_queue"`
 	Status        PryTransactionStatus   `json:"status"`
 	MetaData      map[string]interface{} `json:"meta_data,omitempty"`

--- a/validate_transactions.go
+++ b/validate_transactions.go
@@ -34,14 +34,14 @@ func ValidateCreateTransacation(t CreateTransactionRequest) error {
 	}
 
 	if len(t.Sources) > 0 {
-		err := validateSources(t.Sources, t.Amount, sb)
+		err := validateSources(t.Sources, t.Amount, &sb)
 		if err != nil {
 			return err
 		}
 	}
 
 	if len(t.Destinations) > 0 {
-		err := validateSources(t.Destinations, t.Amount, sb)
+		err := validateSources(t.Destinations, t.Amount, &sb)
 		if err != nil {
 			return err
 		}
@@ -50,7 +50,7 @@ func ValidateCreateTransacation(t CreateTransactionRequest) error {
 	return nil
 }
 
-func validateSources(sources []Source, amount float64, sb strings.Builder) error {
+func validateSources(sources []Source, amount float64, sb *strings.Builder) error {
 	//total amount of sources  must be equal to the amount
 	total := 0.0
 	hasLeft := false
@@ -59,7 +59,7 @@ func validateSources(sources []Source, amount float64, sb strings.Builder) error
 		//check if the distribution is valid
 		isValid := distribution.IsValid()
 		if !isValid {
-			sb.WriteString("invalid distribution")
+			sb.WriteString("invalid distribution: " + string(distribution))
 			return errors.New(sb.String())
 		}
 


### PR DESCRIPTION
This pull request includes various changes to improve the codebase by updating regex patterns, adding a new example, and modifying validation logic. The most important changes include updating regex patterns in `constants.go`, adding a new example in `examples/multi-sources/main.go`, and modifying the `validateSources` function to use a pointer for the `strings.Builder` parameter.

closes #6 

### Regex Pattern Updates:
* [`constants.go`](diffhunk://#diff-25015a3bc3d26727834056ce5eb165af6fc8f8d5ee4142eb2a96872ec8fe501fL11-R12): Updated `percentageRegex` and `numberRegex` to support decimal values.

### New Example:
* [`examples/multi-sources/main.go`](diffhunk://#diff-00b5e27f11a58de46162da240fddbfaa3d49df98db6aadf3be59d48680083be6R1-R38): Added a new example demonstrating the creation of a transaction with multiple sources.

### Validation Logic Modifications:
* [`validate_transactions.go`](diffhunk://#diff-df86942e9d17cf203eb886d45d2d59356da456705222557313c16d40db00b44eL37-R44): Changed the `validateSources` function to use a pointer for the `strings.Builder` parameter and improved error messages. [[1]](diffhunk://#diff-df86942e9d17cf203eb886d45d2d59356da456705222557313c16d40db00b44eL37-R44) [[2]](diffhunk://#diff-df86942e9d17cf203eb886d45d2d59356da456705222557313c16d40db00b44eL53-R53) [[3]](diffhunk://#diff-df86942e9d17cf203eb886d45d2d59356da456705222557313c16d40db00b44eL62-R62)

### Struct Field Update:
* [`transaction.go`](diffhunk://#diff-63ab601287b8b9c040760fe0bdd288f55b73f37cd7e4f1e519bea2bd43a18bbaL30-R30): Made the `PreciseAmount` field in the `ParentTransaction` struct optional by adding the `omitempty` tag.