### PR TITLE
refactor: Change balance fields to use big.Int 

### DIFF
--- a/ledger_balance.go
+++ b/ledger_balance.go
@@ -12,7 +12,7 @@ type LedgerBalanceService service
 type LedgerBalance struct {
 	BalanceID             string                 `json:"balance_id"`
 	Balance               *big.Int               `json:"balance"`
-	Version               *big.Int               `json:"version"`
+	Version               int64                  `json:"version"`
 	InflightBalance       *big.Int               `json:"inflight_balance"`
 	CreditBalance         *big.Int               `json:"credit_balance"`
 	InflightCreditBalance *big.Int               `json:"inflight_credit_balance"`

--- a/ledger_balance.go
+++ b/ledger_balance.go
@@ -2,6 +2,7 @@ package blnkgo
 
 import (
 	"fmt"
+	"math/big"
 	"net/http"
 	"time"
 )
@@ -10,15 +11,15 @@ type LedgerBalanceService service
 
 type LedgerBalance struct {
 	BalanceID             string                 `json:"balance_id"`
-	Balance               int                    `json:"balance"`
-	Version               int                    `json:"version"`
-	InflightBalance       int                    `json:"inflight_balance"`
-	CreditBalance         int                    `json:"credit_balance"`
-	InflightCreditBalance int                    `json:"inflight_credit_balance"`
-	DebitBalance          int                    `json:"debit_balance"`
-	InflightDebitBalance  int                    `json:"inflight_debit_balance"`
-	QueuedDebitBalance    int                    `json:"queued_debit_balance,omitempty"`
-	QueuedCreditBalance   int                    `json:"queued_credit_balance,omitempty"`
+	Balance               *big.Int               `json:"balance"`
+	Version               *big.Int               `json:"version"`
+	InflightBalance       *big.Int               `json:"inflight_balance"`
+	CreditBalance         *big.Int               `json:"credit_balance"`
+	InflightCreditBalance *big.Int               `json:"inflight_credit_balance"`
+	DebitBalance          *big.Int               `json:"debit_balance"`
+	InflightDebitBalance  *big.Int               `json:"inflight_debit_balance"`
+	QueuedDebitBalance    *big.Int               `json:"queued_debit_balance,omitempty"`
+	QueuedCreditBalance   *big.Int               `json:"queued_credit_balance,omitempty"`
 	CurrencyMultiplier    float64                `json:"currency_multiplier"`
 	Precision             int                    `json:"precision"`
 	LedgerID              string                 `json:"ledger_id"`


### PR DESCRIPTION
This pull request includes changes to the `ledger_balance.go` file in the `blnkgo` package, focusing on improving precision and handling of ledger balances by using the `big.Int` type for various balance-related fields.

Changes to improve precision:

* [`ledger_balance.go`](diffhunk://#diff-0ee4b55ce5a272a497144355d9362d172d798040fe7ad60396f0c38a71ea5349R5): Imported the `math/big` package to utilize the `big.Int` type for high-precision arithmetic.

Changes to balance fields:

* [`ledger_balance.go`](diffhunk://#diff-0ee4b55ce5a272a497144355d9362d172d798040fe7ad60396f0c38a71ea5349L13-R22): Updated the `LedgerBalance` struct to replace integer fields (`Balance`, `Version`, `InflightBalance`, `CreditBalance`, `InflightCreditBalance`, `DebitBalance`, `InflightDebitBalance`, `QueuedDebitBalance`, `QueuedCreditBalance`) with `*big.Int` to enhance precision and handle larger values.