### PR TITLE
fix(search): :white_check_mark: add missing EffectiveDate field to SearchDocument

### DIFF
--- a/search.go
+++ b/search.go
@@ -117,6 +117,7 @@ type SearchDocument struct {
 	SkipQueue          bool         `json:"skip_queue,omitempty"`
 	Rate               float64      `json:"rate,omitempty"`
 	PreciseAmount      float64      `json:"precise_amount,omitempty"`
+	EffectiveDate      FlexibleTime `json:"effective_date,omitempty"`
 
 	// Ledger fields
 	Name string `json:"name,omitempty"`


### PR DESCRIPTION
- Add missing EffectiveDate field with FlexibleTime type
- Update tests to ensure proper parsing of effective_date
- Ensures API response compatibility

Alterações feitas por **Rafael Carvalho**