### PR TITLE
Add unit tests for LedgerBalanceService.GetHistorical

### DIFF
--- a/ledger_balance_historical.go
+++ b/ledger_balance_historical.go
@@ -1,0 +1,49 @@
+package blnkgo
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+	"time"
+)
+
+type BalanceDetails struct {
+	Balance       *big.Int `json:"balance"`
+	BalanceID     string   `json:"balance_id"`
+	CreditBalance *big.Int `json:"credit_balance"`
+	Currency      string   `json:"currency"`
+	DebitBalance  *big.Int `json:"debit_balance"`
+}
+
+type LedgerBalanceHistorical struct {
+	Balance    BalanceDetails `json:"balance"`
+	FromSource bool           `json:"from_source"`
+	Timestamp  time.Time      `json:"timestamp"`
+}
+
+func (s *LedgerBalanceService) GetHistorical(balanceID string, timestamp time.Time, fromSource bool) (*LedgerBalanceHistorical, *http.Response, error) {
+	if balanceID == "" {
+		return nil, nil, fmt.Errorf("invalid: balanceID is required")
+	}
+	if timestamp.IsZero() {
+		return nil, nil, fmt.Errorf("invalid: timestamp is required")
+	}
+	// Use RFC3339 with offset (e.g., 2025-08-30T01:38:30-03:00)
+	ts := timestamp.Format(time.RFC3339)
+	u := fmt.Sprintf("balances/%s/at?timestamp=%s", balanceID, ts)
+	if fromSource {
+		u += "&from_source=true"
+	}
+	req, err := s.client.NewRequest(u, http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	responseData := new(LedgerBalanceHistorical)
+	resp, err := s.client.CallWithRetry(req, responseData)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return responseData, resp, nil
+}

--- a/ledger_balance_historical_test.go
+++ b/ledger_balance_historical_test.go
@@ -1,0 +1,80 @@
+package blnkgo_test
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLedgerBalanceService_GetHistorical_Success(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bal-123"
+	timestamp := time.Date(2023, 8, 29, 12, 0, 0, 0, time.FixedZone("-03:00", -3*60*60))
+	endpoint := fmt.Sprintf("balances/%s/at?timestamp=%s", balanceID, timestamp.Format(time.RFC3339))
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{}, nil).Run(func(args mock.Arguments) {
+		respData := args.Get(1).(*blnkgo.LedgerBalanceHistorical)
+		respData.Balance.Balance = big.NewInt(1000)
+		respData.Balance.BalanceID = balanceID
+		respData.Balance.CreditBalance = big.NewInt(2000)
+		respData.Balance.Currency = "USD"
+		respData.Balance.DebitBalance = big.NewInt(1000)
+		respData.FromSource = true
+		respData.Timestamp = timestamp
+	})
+	bal, resp, err := svc.GetHistorical(balanceID, timestamp, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, bal)
+	assert.Equal(t, big.NewInt(1000), bal.Balance.Balance)
+	assert.Equal(t, balanceID, bal.Balance.BalanceID)
+	assert.Equal(t, big.NewInt(2000), bal.Balance.CreditBalance)
+	assert.Equal(t, "USD", bal.Balance.Currency)
+	assert.Equal(t, big.NewInt(1000), bal.Balance.DebitBalance)
+	assert.True(t, bal.FromSource)
+	assert.True(t, bal.Timestamp.Equal(timestamp))
+	assert.NotNil(t, resp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_GetHistorical_InvalidBalanceID(t *testing.T) {
+	_, svc := setupLedgerBalanceService()
+	bal, resp, err := svc.GetHistorical("", time.Now(), false)
+	assert.Error(t, err)
+	assert.Nil(t, bal)
+	assert.Nil(t, resp)
+}
+
+func TestLedgerBalanceService_GetHistorical_InvalidTimestamp(t *testing.T) {
+	_, svc := setupLedgerBalanceService()
+	bal, resp, err := svc.GetHistorical("bal-123", time.Time{}, false)
+	assert.Error(t, err)
+	assert.Nil(t, bal)
+	assert.Nil(t, resp)
+}
+
+func TestLedgerBalanceService_GetHistorical_NewRequestError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	mockClient.On("NewRequest", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("request error")) // Mantém compatível
+	bal, resp, err := svc.GetHistorical("bal-123", time.Now(), false)
+	assert.Error(t, err)
+	assert.Nil(t, bal)
+	assert.Nil(t, resp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_GetHistorical_CallWithRetryError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	mockClient.On("NewRequest", mock.Anything, mock.Anything, mock.Anything).Return(&http.Request{}, nil) // Mantém compatível
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("call error"))
+	bal, resp, err := svc.GetHistorical("bal-123", time.Now(), false)
+	assert.Error(t, err)
+	assert.Nil(t, bal)
+	assert.Nil(t, resp)
+	mockClient.AssertExpectations(t)
+}

--- a/transaction.go
+++ b/transaction.go
@@ -32,7 +32,7 @@ type ParentTransaction struct {
 	SkipQueue     bool                   `json:"skip_queue"`
 	Status        PryTransactionStatus   `json:"status"`
 	MetaData      map[string]interface{} `json:"meta_data,omitempty"`
-	EffectiveDate time.Time              `json:"effective_date"`
+	EffectiveDate *time.Time             `json:"effective_date"`
 }
 
 type CreateTransactionRequest struct {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -117,7 +117,7 @@ func TestUpdateTransaction(t *testing.T) {
 					},
 					Description:   "Alice Funds",
 					Status:        blnkgo.PryTransactionStatus(tt.body.Status),
-					EffectiveDate: effectiveDate,
+					EffectiveDate: &effectiveDate,
 				},
 				TransactionID: "tx-123",
 				CreatedAt:     fixedTime,
@@ -276,7 +276,7 @@ func TestCreateTransactionSuccess(t *testing.T) {
 				"customer_id":      "alice-5786",
 			},
 			Description:   "Alice Funds",
-			EffectiveDate: effectiveDate,
+			EffectiveDate: &effectiveDate,
 		},
 		Inflight: true,
 	}
@@ -386,7 +386,7 @@ func TestRefundTransaction(t *testing.T) {
 			Source:        "@bank-account",
 			Destination:   "@World",
 			Description:   "",
-			EffectiveDate: effectiveDate,
+			EffectiveDate: &effectiveDate,
 		},
 	}
 	fixedTime := time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC)
@@ -471,7 +471,7 @@ func TestTransactionService_Get(t *testing.T) {
 						Destination:   "@World",
 						Status:        blnkgo.PryTransactionStatusApplied,
 						Description:   "Test Transaction",
-						EffectiveDate: effectiveDate,
+						EffectiveDate: &effectiveDate,
 					},
 					TransactionID: "tx-123",
 					CreatedAt:     fixedTime,


### PR DESCRIPTION
This PR adds the GetHistorical method to LedgerBalanceService, enabling retrieval of historical balances for a given balance ID at a specific timestamp, with an option to fetch data directly from the source.

- Introduces the LedgerBalanceHistorical struct to represent the response.
- Implements parameter validation and error handling.
- Follows the existing code and organization patterns of the project.


Resolves: #20