### PR TITLE
Support inflight fields in transaction requests and search results

### DIFF
--- a/search.go
+++ b/search.go
@@ -96,13 +96,16 @@ type SearchDocument struct {
 	MetaData  interface{}  `json:"meta_data"`  // Can be string, map, or other types
 
 	// Balance fields
-	BalanceID     string `json:"balance_id,omitempty"`
-	Balance       string `json:"balance,omitempty"`
-	CreditBalance string `json:"credit_balance,omitempty"`
-	DebitBalance  string `json:"debit_balance,omitempty"`
-	Currency      string `json:"currency,omitempty"`
-	Precision     int    `json:"precision,omitempty"`
-	LedgerID      string `json:"ledger_id,omitempty"`
+	BalanceID             string `json:"balance_id,omitempty"`
+	Balance               string `json:"balance,omitempty"`
+	CreditBalance         string `json:"credit_balance,omitempty"`
+	DebitBalance          string `json:"debit_balance,omitempty"`
+	Currency              string `json:"currency,omitempty"`
+	Precision             int    `json:"precision,omitempty"`
+	LedgerID              string `json:"ledger_id,omitempty"`
+	InflightBalance       string `json:"inflight_balance"`
+	InflightCreditBalance string `json:"inflight_credit_balance"`
+	InflightDebitBalance  string `json:"inflight_debit_balance"`
 
 	// Transaction fields
 	TransactionID      string       `json:"transaction_id,omitempty"`

--- a/search_test.go
+++ b/search_test.go
@@ -46,15 +46,18 @@ func TestSearchService_SearchDocument_Success(t *testing.T) {
 		Hits: []blnkgo.SearchHit{
 			{
 				Document: blnkgo.SearchDocument{
-					BalanceID:     "balance123",
-					Balance:       "100.0",
-					CreditBalance: "50.0",
-					DebitBalance:  "50.0",
-					Currency:      "USD",
-					Precision:     2,
-					LedgerID:      "ledger123",
-					CreatedAt:     blnkgo.FlexibleTime{Time: time.Now()},
-					MetaData:      map[string]interface{}{"key": "value"},
+					BalanceID:             "balance123",
+					Balance:               "100.0",
+					CreditBalance:         "50.0",
+					DebitBalance:          "50.0",
+					Currency:              "USD",
+					Precision:             2,
+					LedgerID:              "ledger123",
+					InflightBalance:       "25.0",
+					InflightCreditBalance: "15.0",
+					InflightDebitBalance:  "10.0",
+					CreatedAt:             blnkgo.FlexibleTime{Time: time.Now()},
+					MetaData:              map[string]interface{}{"key": "value"},
 				},
 			},
 		},
@@ -329,6 +332,38 @@ func TestSearchDocument_MetaData_FlexibleTypes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSearchDocument_BalanceInflightFields(t *testing.T) {
+	balanceJSON := `{
+		"balance_id": "bal-123",
+		"balance": "100.50",
+		"credit_balance": "75.25",
+		"debit_balance": "25.25",
+		"inflight_balance": "10.00",
+		"inflight_credit_balance": "7.50",
+		"inflight_debit_balance": "2.50",
+		"currency": "USD",
+		"ledger_id": "ledger-123",
+		"created_at": 1672531200,
+		"meta_data": {"owner": "customer-1"}
+	}`
+
+	var doc blnkgo.SearchDocument
+	err := json.Unmarshal([]byte(balanceJSON), &doc)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bal-123", doc.BalanceID)
+	assert.Equal(t, "100.50", doc.Balance)
+	assert.Equal(t, "75.25", doc.CreditBalance)
+	assert.Equal(t, "25.25", doc.DebitBalance)
+	assert.Equal(t, "10.00", doc.InflightBalance)
+	assert.Equal(t, "7.50", doc.InflightCreditBalance)
+	assert.Equal(t, "2.50", doc.InflightDebitBalance)
+	assert.Equal(t, "USD", doc.Currency)
+	assert.Equal(t, "ledger-123", doc.LedgerID)
+	assert.Equal(t, time.Unix(1672531200, 0), doc.CreatedAt.Time)
+	assert.NotNil(t, doc.MetaData)
 }
 
 func TestSearchDocument_TransactionFields(t *testing.T) {

--- a/transaction.go
+++ b/transaction.go
@@ -37,6 +37,7 @@ type CreateTransactionRequest struct {
 	ParentTransaction
 	Inflight           bool       `json:"inflight,omitempty"`
 	InflightExpiryDate *time.Time `json:"inflight_expiry_date,omitempty"`
+	InflightCommitDate *time.Time `json:"inflight_commit_date,omitempty"`
 	ScheduledFor       *time.Time `json:"scheduled_for,omitempty"`
 	AllowOverdraft     bool       `json:"allow_overdraft,omitempty"`
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -678,3 +678,134 @@ func TestTransactionService_Filter_ServerError(t *testing.T) {
 	assert.Equal(t, expectedResp, resp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestCreateTransactionWithInflightCommitDate(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	effectiveDate := time.Date(2023, time.September, 20, 14, 30, 0, 0, time.UTC)
+	inflightCommitDate := time.Date(2023, time.September, 25, 10, 0, 0, 0, time.UTC)
+
+	body := blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      1000,
+			Reference:   "ref-inflight-commit",
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@bank-account",
+			Destination: "@World",
+			MetaData: map[string]interface{}{
+				"transaction_type": "deposit",
+				"customer_name":    "Bob Smith",
+				"customer_id":      "bob-1234",
+			},
+			Description:   "Inflight Commit Test",
+			EffectiveDate: &effectiveDate,
+		},
+		Inflight:           true,
+		InflightCommitDate: &inflightCommitDate,
+	}
+	fixedTime := time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC)
+
+	mockClient.On("NewRequest", "transactions", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusCreated}, nil).Run(func(args mock.Arguments) {
+		transaction := args.Get(1).(*blnkgo.Transaction)
+		*transaction = blnkgo.Transaction{
+			ParentTransaction: body.ParentTransaction,
+			TransactionID:     "txn-inflight-commit-123",
+			CreatedAt:         fixedTime,
+		}
+	})
+
+	transaction, resp, err := svc.Create(body)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, "txn-inflight-commit-123", transaction.TransactionID)
+	assert.Equal(t, fixedTime, transaction.CreatedAt)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestCreateTransactionWithInflightExpiryAndCommitDate(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	effectiveDate := time.Date(2023, time.September, 20, 14, 30, 0, 0, time.UTC)
+	inflightExpiryDate := time.Date(2023, time.September, 30, 23, 59, 59, 0, time.UTC)
+	inflightCommitDate := time.Date(2023, time.September, 25, 10, 0, 0, 0, time.UTC)
+
+	body := blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      2500,
+			Reference:   "ref-both-dates",
+			Precision:   100,
+			Currency:    "EUR",
+			Source:      "@escrow-account",
+			Destination: "@merchant",
+			MetaData: map[string]interface{}{
+				"transaction_type": "escrow_release",
+				"order_id":         "order-9876",
+			},
+			Description:   "Escrow with both dates",
+			EffectiveDate: &effectiveDate,
+		},
+		Inflight:           true,
+		InflightExpiryDate: &inflightExpiryDate,
+		InflightCommitDate: &inflightCommitDate,
+	}
+	fixedTime := time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC)
+
+	mockClient.On("NewRequest", "transactions", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusCreated}, nil).Run(func(args mock.Arguments) {
+		transaction := args.Get(1).(*blnkgo.Transaction)
+		*transaction = blnkgo.Transaction{
+			ParentTransaction: body.ParentTransaction,
+			TransactionID:     "txn-both-dates-456",
+			CreatedAt:         fixedTime,
+		}
+	})
+
+	transaction, resp, err := svc.Create(body)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, "txn-both-dates-456", transaction.TransactionID)
+	assert.Equal(t, fixedTime, transaction.CreatedAt)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestCreateTransactionInflightCommitDateWithoutInflight(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	inflightCommitDate := time.Date(2023, time.September, 25, 10, 0, 0, 0, time.UTC)
+
+	body := blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      500,
+			Reference:   "ref-commit-no-inflight",
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@bank-account",
+			Destination: "@World",
+			Description: "Commit date without inflight flag",
+		},
+		Inflight:           false,
+		InflightCommitDate: &inflightCommitDate,
+	}
+	fixedTime := time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC)
+
+	mockClient.On("NewRequest", "transactions", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusCreated}, nil).Run(func(args mock.Arguments) {
+		transaction := args.Get(1).(*blnkgo.Transaction)
+		*transaction = blnkgo.Transaction{
+			ParentTransaction: body.ParentTransaction,
+			TransactionID:     "txn-no-inflight-789",
+			CreatedAt:         fixedTime,
+		}
+	})
+
+	transaction, resp, err := svc.Create(body)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, "txn-no-inflight-789", transaction.TransactionID)
+
+	mockClient.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

This PR updates the Go client to support additional inflight fields returned and accepted by the API.

## What changed

- add `inflight_commit_date` to transaction creation requests
- add `inflight_balance`, `inflight_credit_balance`, and `inflight_debit_balance` to search documents
- extend transaction tests to cover request payloads with inflight commit date
- extend search tests to verify inflight balance fields are mapped correctly

## Why

The API now exposes inflight state in more places than the client currently supports. This change keeps the client in sync so consumers can:

- send `inflight_commit_date` when creating transactions
- read inflight balance values from search responses