### PR TITLE
feat(ledger): add Ledger.Update (closes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ func main() {
 
 This creates a new ledger for storing customer balances.
 
+### Updating a Ledger Name
+
+Rename an existing ledger without changing its ID or affecting balances and transactions:
+
+```go
+updateBody := blnkgo.UpdateLedgerRequest{
+    Name: "Updated Customer Savings Account",
+}
+
+updatedLedger, resp, err := client.Ledger.Update(newLedger.LedgerID, updateBody)
+if err != nil {
+    fmt.Printf("Error updating ledger: %v\n", err)
+    return
+}
+
+fmt.Printf("Ledger Updated: %+v\n", updatedLedger)
+```
+
 ---
 
 ## 5. Creating Balances

--- a/ledger.go
+++ b/ledger.go
@@ -20,6 +20,10 @@ type CreateLedgerRequest struct {
 	MetaData map[string]interface{} `json:"meta_data,omitempty"`
 }
 
+type UpdateLedgerRequest struct {
+	Name string `json:"name"`
+}
+
 func (s *LedgerService) List() ([]Ledger, *http.Response, error) {
 	req, err := s.client.NewRequest("ledgers", http.MethodGet, nil)
 	if err != nil {
@@ -54,6 +58,28 @@ func (s *LedgerService) Get(id string) (*Ledger, *http.Response, error) {
 
 func (s *LedgerService) Create(body CreateLedgerRequest) (*Ledger, *http.Response, error) {
 	req, err := s.client.NewRequest("ledgers", http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ledger := new(Ledger)
+	resp, err := s.client.CallWithRetry(req, ledger)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ledger, resp, nil
+}
+
+func (s *LedgerService) Update(id string, body UpdateLedgerRequest) (*Ledger, *http.Response, error) {
+	if id == "" {
+		return nil, nil, fmt.Errorf("invalid: id is required")
+	}
+	if body.Name == "" {
+		return nil, nil, fmt.Errorf("invalid: name is required")
+	}
+	u := fmt.Sprintf("ledgers/%s", id)
+	req, err := s.client.NewRequest(u, http.MethodPut, body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -168,6 +168,118 @@ func TestLedgerSerice_Get_EmptyID(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestLedgerService_Update_Success(t *testing.T) {
+	mockClient, svc := setupLedgerService()
+	ledgerID := "ldg_123"
+	body := blnkgo.UpdateLedgerRequest{
+		Name: "Updated Customer Savings Account",
+	}
+
+	fixedTime := time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC)
+	expectedResponse := &blnkgo.Ledger{
+		LedgerID:  ledgerID,
+		Name:      body.Name,
+		CreatedAt: fixedTime,
+	}
+
+	mockClient.On("NewRequest", fmt.Sprintf("ledgers/%s", ledgerID), http.MethodPut, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		ledger := args.Get(1).(*blnkgo.Ledger)
+		*ledger = *expectedResponse
+	})
+
+	ledger, resp, err := svc.Update(ledgerID, body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, ledger)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerService_Update_CorrectEndpoint(t *testing.T) {
+	mockClient, svc := setupLedgerService()
+	ledgerID := "ldg_123"
+	body := blnkgo.UpdateLedgerRequest{Name: "Updated Name"}
+	expectedEndpoint := fmt.Sprintf("ledgers/%s", ledgerID)
+
+	mockClient.On("NewRequest", expectedEndpoint, http.MethodPut, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, _ = svc.Update(ledgerID, body)
+
+	mockClient.AssertCalled(t, "NewRequest", expectedEndpoint, http.MethodPut, body)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerService_Update_EmptyID(t *testing.T) {
+	mockClient, svc := setupLedgerService()
+	body := blnkgo.UpdateLedgerRequest{Name: "Updated Name"}
+
+	ledger, resp, err := svc.Update("", body)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "id is required")
+	assert.Nil(t, ledger)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerService_Update_EmptyName(t *testing.T) {
+	mockClient, svc := setupLedgerService()
+	body := blnkgo.UpdateLedgerRequest{}
+
+	ledger, resp, err := svc.Update("ldg_123", body)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "name is required")
+	assert.Nil(t, ledger)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerService_Update_NewRequestError(t *testing.T) {
+	mockClient, svc := setupLedgerService()
+	ledgerID := "ldg_123"
+	body := blnkgo.UpdateLedgerRequest{Name: "Updated Name"}
+
+	mockClient.On("NewRequest", fmt.Sprintf("ledgers/%s", ledgerID), http.MethodPut, body).
+		Return(nil, fmt.Errorf("request error"))
+
+	ledger, resp, err := svc.Update(ledgerID, body)
+
+	assert.Error(t, err)
+	assert.Nil(t, ledger)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerService_Update_ServerError(t *testing.T) {
+	mockClient, svc := setupLedgerService()
+	ledgerID := "ldg_123"
+	body := blnkgo.UpdateLedgerRequest{Name: "Updated Name"}
+	expectedResp := &http.Response{StatusCode: http.StatusInternalServerError}
+
+	mockClient.On("NewRequest", fmt.Sprintf("ledgers/%s", ledgerID), http.MethodPut, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(expectedResp, fmt.Errorf("server error"))
+
+	ledger, resp, err := svc.Update(ledgerID, body)
+
+	assert.Error(t, err)
+	assert.Nil(t, ledger)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}
+
 func TestLedgerService_Filter_Success(t *testing.T) {
 	mockClient, svc := setupLedgerService()
 


### PR DESCRIPTION
## Summary
- Adds `Ledger.Update(id, UpdateLedgerRequest)` calling `PUT /ledgers/{id}` to match Blnk Core v0.14.3
- Introduces `UpdateLedgerRequest` with required `name` field, aligned with the [update ledger name API reference](https://docs.blnkfinance.com/reference/update-ledger-name)
- Validates `id` and `name` client-side before sending the request
- Adds six mocked unit tests following existing `ledger_test.go` patterns
- Documents ledger rename usage in README

Closes #31

## Acceptance criteria
- [x] Add `Ledger.Update` calling `/ledgers/{id}`
- [x] Request/response Go types match reference fields
- [x] Client-side validation (if any) aligned with API rules
- [x] Unit test with mocked HTTP (follow existing `*_test.go` patterns)
- [x] Example or note in README / Go SDK docs

## Test plan
- [x] `go test ./... -run LedgerService_Update -v`
- [x] `go test ./...`