### PR TITLE
feat(balances): add LedgerBalance.GetLineage (closes #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,21 @@ if err != nil {
 fmt.Printf("Balance Created: %+v\n", newBalance)
 ```
 
+### Viewing Balance Lineage
+
+For balances with fund lineage tracking enabled, retrieve the provider breakdown (received, spent, available):
+
+```go
+lineage, resp, err := client.LedgerBalance.GetLineage(newBalance.BalanceID)
+if err != nil {
+    fmt.Printf("Error fetching balance lineage: %v\n", err)
+    return
+}
+
+fmt.Printf("Balance Lineage: %+v\n", lineage)
+fmt.Printf("Total with lineage: %s\n", lineage.TotalWithLineage.String())
+```
+
 ---
 
 ## 6. Recording Transactions

--- a/ledger_balance_lineage.go
+++ b/ledger_balance_lineage.go
@@ -1,6 +1,7 @@
 package blnkgo
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -23,6 +24,86 @@ type BalanceLineage struct {
 	AggregateBalanceID string                     `json:"aggregate_balance_id"`
 	TotalWithLineage   *big.Int                   `json:"total_with_lineage"`
 	Providers          []LineageProviderBreakdown `json:"providers"`
+}
+
+func unmarshalBigIntJSON(data []byte) (*big.Int, error) {
+	if string(data) == "null" {
+		return nil, nil
+	}
+
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err == nil {
+		v, ok := new(big.Int).SetString(n.String(), 10)
+		if ok {
+			return v, nil
+		}
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		v, ok := new(big.Int).SetString(s, 10)
+		if ok {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot parse big.Int from %s", string(data))
+}
+
+func (p *LineageProviderBreakdown) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Provider        string          `json:"provider"`
+		Amount          json.RawMessage `json:"amount"`
+		Available       json.RawMessage `json:"available"`
+		Spent           json.RawMessage `json:"spent"`
+		ShadowBalanceID string          `json:"shadow_balance_id"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	amount, err := unmarshalBigIntJSON(raw.Amount)
+	if err != nil {
+		return err
+	}
+	available, err := unmarshalBigIntJSON(raw.Available)
+	if err != nil {
+		return err
+	}
+	spent, err := unmarshalBigIntJSON(raw.Spent)
+	if err != nil {
+		return err
+	}
+
+	p.Provider = raw.Provider
+	p.Amount = amount
+	p.Available = available
+	p.Spent = spent
+	p.ShadowBalanceID = raw.ShadowBalanceID
+	return nil
+}
+
+func (b *BalanceLineage) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		BalanceID          string                     `json:"balance_id"`
+		AggregateBalanceID string                     `json:"aggregate_balance_id"`
+		TotalWithLineage   json.RawMessage            `json:"total_with_lineage"`
+		Providers          []LineageProviderBreakdown `json:"providers"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	total, err := unmarshalBigIntJSON(raw.TotalWithLineage)
+	if err != nil {
+		return err
+	}
+
+	b.BalanceID = raw.BalanceID
+	b.AggregateBalanceID = raw.AggregateBalanceID
+	b.TotalWithLineage = total
+	b.Providers = raw.Providers
+	return nil
 }
 
 func (s *LedgerBalanceService) GetLineage(balanceID string) (*BalanceLineage, *http.Response, error) {

--- a/ledger_balance_lineage.go
+++ b/ledger_balance_lineage.go
@@ -1,0 +1,46 @@
+package blnkgo
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+)
+
+// LineageProviderBreakdown is the per-provider fund breakdown for a balance with
+// fund lineage tracking enabled.
+type LineageProviderBreakdown struct {
+	Provider        string   `json:"provider"`
+	Amount          *big.Int `json:"amount"`
+	Available       *big.Int `json:"available"`
+	Spent           *big.Int `json:"spent"`
+	ShadowBalanceID string   `json:"shadow_balance_id"`
+}
+
+// BalanceLineage is the fund lineage view for a balance, including provider-level
+// received, spent, and available amounts (minor units).
+type BalanceLineage struct {
+	BalanceID          string                     `json:"balance_id"`
+	AggregateBalanceID string                     `json:"aggregate_balance_id"`
+	TotalWithLineage   *big.Int                   `json:"total_with_lineage"`
+	Providers          []LineageProviderBreakdown `json:"providers"`
+}
+
+func (s *LedgerBalanceService) GetLineage(balanceID string) (*BalanceLineage, *http.Response, error) {
+	if balanceID == "" {
+		return nil, nil, fmt.Errorf("invalid: balanceID is required")
+	}
+
+	u := fmt.Sprintf("balances/%s/lineage", balanceID)
+	req, err := s.client.NewRequest(u, http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lineage := new(BalanceLineage)
+	resp, err := s.client.CallWithRetry(req, lineage)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return lineage, resp, nil
+}

--- a/ledger_balance_lineage_test.go
+++ b/ledger_balance_lineage_test.go
@@ -1,0 +1,112 @@
+package blnkgo_test
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLedgerBalanceService_GetLineage_Success(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f"
+
+	expectedResponse := &blnkgo.BalanceLineage{
+		BalanceID:          balanceID,
+		AggregateBalanceID: "bln_aggregate_shadow_balance_id",
+		TotalWithLineage:   big.NewInt(7500),
+		Providers: []blnkgo.LineageProviderBreakdown{
+			{
+				Provider:        "stripe",
+				Amount:          big.NewInt(10000),
+				Available:       big.NewInt(7500),
+				Spent:           big.NewInt(2500),
+				ShadowBalanceID: "bln_shadow_balance_id",
+			},
+		},
+	}
+
+	endpoint := fmt.Sprintf("balances/%s/lineage", balanceID)
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		lineage := args.Get(1).(*blnkgo.BalanceLineage)
+		*lineage = *expectedResponse
+	})
+
+	lineage, resp, err := svc.GetLineage(balanceID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, lineage)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_GetLineage_CorrectEndpoint(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f"
+	endpoint := fmt.Sprintf("balances/%s/lineage", balanceID)
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, _ = svc.GetLineage(balanceID)
+
+	mockClient.AssertCalled(t, "NewRequest", endpoint, http.MethodGet, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_GetLineage_EmptyID(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+
+	lineage, resp, err := svc.GetLineage("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "balanceID is required")
+	assert.Nil(t, lineage)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_GetLineage_NewRequestError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f"
+	endpoint := fmt.Sprintf("balances/%s/lineage", balanceID)
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(nil, fmt.Errorf("request error"))
+
+	lineage, resp, err := svc.GetLineage(balanceID)
+
+	assert.Error(t, err)
+	assert.Nil(t, lineage)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_GetLineage_ServerError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f"
+	endpoint := fmt.Sprintf("balances/%s/lineage", balanceID)
+	expectedResp := &http.Response{StatusCode: http.StatusInternalServerError}
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(expectedResp, fmt.Errorf("server error"))
+
+	lineage, resp, err := svc.GetLineage(balanceID)
+
+	assert.Error(t, err)
+	assert.Nil(t, lineage)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}

--- a/ledger_balance_lineage_test.go
+++ b/ledger_balance_lineage_test.go
@@ -1,6 +1,7 @@
 package blnkgo_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -10,6 +11,66 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+// TestBalanceLineage_UnmarshalJSON verifies BalanceLineage decodes the API
+// response contract from docs.blnkfinance.com/reference/get-balance-lineage.
+func TestBalanceLineage_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name: "docs example with string amounts",
+			payload: `{
+				"balance_id": "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f",
+				"aggregate_balance_id": "bln_aggregate_shadow_balance_id",
+				"total_with_lineage": "7500",
+				"providers": [{
+					"provider": "stripe",
+					"amount": "10000",
+					"available": "7500",
+					"spent": "2500",
+					"shadow_balance_id": "bln_shadow_balance_id"
+				}]
+			}`,
+		},
+		{
+			name: "core serialization with numeric amounts",
+			payload: `{
+				"balance_id": "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f",
+				"aggregate_balance_id": "bln_aggregate_shadow_balance_id",
+				"total_with_lineage": 7500,
+				"providers": [{
+					"provider": "stripe",
+					"amount": 10000,
+					"available": 7500,
+					"spent": 2500,
+					"shadow_balance_id": "bln_shadow_balance_id"
+				}]
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var lineage blnkgo.BalanceLineage
+			err := json.Unmarshal([]byte(tt.payload), &lineage)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f", lineage.BalanceID)
+			assert.Equal(t, "bln_aggregate_shadow_balance_id", lineage.AggregateBalanceID)
+			assert.Equal(t, 0, big.NewInt(7500).Cmp(lineage.TotalWithLineage))
+			assert.Len(t, lineage.Providers, 1)
+
+			provider := lineage.Providers[0]
+			assert.Equal(t, "stripe", provider.Provider)
+			assert.Equal(t, 0, big.NewInt(10000).Cmp(provider.Amount))
+			assert.Equal(t, 0, big.NewInt(7500).Cmp(provider.Available))
+			assert.Equal(t, 0, big.NewInt(2500).Cmp(provider.Spent))
+			assert.Equal(t, "bln_shadow_balance_id", provider.ShadowBalanceID)
+		})
+	}
+}
 
 func TestLedgerBalanceService_GetLineage_Success(t *testing.T) {
 	mockClient, svc := setupLedgerBalanceService()


### PR DESCRIPTION
## Summary
- Adds `LedgerBalance.GetLineage(balanceID)` calling `GET /balances/{balance_id}/lineage`
- Introduces `BalanceLineage` and `LineageProviderBreakdown` types aligned with [Core v0.14.3](https://docs.blnkfinance.com/reference/get-balance-lineage)
- Validates `balanceID` client-side before sending the request
- Adds five mocked unit tests following existing balance service patterns
- Documents balance lineage usage in README

Closes #32

## Acceptance criteria
- [x] Add `LedgerBalance.GetLineage` calling `/balances/{balance_id}/lineage`
- [x] Request/response Go types match reference fields
- [x] Client-side validation (if any) aligned with API rules
- [x] Unit test with mocked HTTP (follow existing `*_test.go` patterns)
- [x] Example or note in README / Go SDK docs

## Test plan
- [x] `go test ./... -run GetLineage -v`
- [x] `go test ./...`