### PR TITLE
feat(balances): add LedgerBalance.UpdateIdentity (closes #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,24 @@ fmt.Printf("Balance Lineage: %+v\n", lineage)
 fmt.Printf("Total with lineage: %s\n", lineage.TotalWithLineage.String())
 ```
 
+### Linking an Identity to a Balance
+
+Associate an existing identity with a balance:
+
+```go
+updateBody := blnkgo.UpdateBalanceIdentityRequest{
+    IdentityID: "idt_3b63c8da-af29-4cc3-ad38-df17d87456e6",
+}
+
+result, resp, err := client.LedgerBalance.UpdateIdentity(newBalance.BalanceID, updateBody)
+if err != nil {
+    fmt.Printf("Error updating balance identity: %v\n", err)
+    return
+}
+
+fmt.Printf("Identity linked: %s\n", result.Message)
+```
+
 ---
 
 ## 6. Recording Transactions

--- a/ledger_balance_identity.go
+++ b/ledger_balance_identity.go
@@ -1,0 +1,37 @@
+package blnkgo
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type UpdateBalanceIdentityRequest struct {
+	IdentityID string `json:"identity_id"`
+}
+
+type UpdateBalanceIdentityResponse struct {
+	Message string `json:"message"`
+}
+
+func (s *LedgerBalanceService) UpdateIdentity(balanceID string, body UpdateBalanceIdentityRequest) (*UpdateBalanceIdentityResponse, *http.Response, error) {
+	if balanceID == "" {
+		return nil, nil, fmt.Errorf("invalid: balanceID is required")
+	}
+	if body.IdentityID == "" {
+		return nil, nil, fmt.Errorf("invalid: identity_id is required")
+	}
+
+	u := fmt.Sprintf("balances/%s/identity", balanceID)
+	req, err := s.client.NewRequest(u, http.MethodPut, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response := new(UpdateBalanceIdentityResponse)
+	resp, err := s.client.CallWithRetry(req, response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response, resp, nil
+}

--- a/ledger_balance_identity_test.go
+++ b/ledger_balance_identity_test.go
@@ -1,0 +1,133 @@
+package blnkgo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLedgerBalanceService_UpdateIdentity_Success(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f"
+	body := blnkgo.UpdateBalanceIdentityRequest{
+		IdentityID: "idt_3b63c8da-af29-4cc3-ad38-df17d87456e6",
+	}
+
+	expectedResponse := &blnkgo.UpdateBalanceIdentityResponse{
+		Message: "Balance identity updated successfully",
+	}
+
+	endpoint := fmt.Sprintf("balances/%s/identity", balanceID)
+	mockClient.On("NewRequest", endpoint, http.MethodPut, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		response := args.Get(1).(*blnkgo.UpdateBalanceIdentityResponse)
+		*response = *expectedResponse
+	})
+
+	response, resp, err := svc.UpdateIdentity(balanceID, body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, response)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_UpdateIdentity_CorrectEndpoint(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f"
+	body := blnkgo.UpdateBalanceIdentityRequest{IdentityID: "idt_3b63c8da-af29-4cc3-ad38-df17d87456e6"}
+	endpoint := fmt.Sprintf("balances/%s/identity", balanceID)
+
+	mockClient.On("NewRequest", endpoint, http.MethodPut, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, _ = svc.UpdateIdentity(balanceID, body)
+
+	mockClient.AssertCalled(t, "NewRequest", endpoint, http.MethodPut, body)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_UpdateIdentity_EmptyBalanceID(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	body := blnkgo.UpdateBalanceIdentityRequest{IdentityID: "idt_3b63c8da-af29-4cc3-ad38-df17d87456e6"}
+
+	response, resp, err := svc.UpdateIdentity("", body)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "balanceID is required")
+	assert.Nil(t, response)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_UpdateIdentity_EmptyIdentityID(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	body := blnkgo.UpdateBalanceIdentityRequest{}
+
+	response, resp, err := svc.UpdateIdentity("bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f", body)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "identity_id is required")
+	assert.Nil(t, response)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_UpdateIdentity_NewRequestError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f"
+	body := blnkgo.UpdateBalanceIdentityRequest{IdentityID: "idt_3b63c8da-af29-4cc3-ad38-df17d87456e6"}
+	endpoint := fmt.Sprintf("balances/%s/identity", balanceID)
+
+	mockClient.On("NewRequest", endpoint, http.MethodPut, body).Return(nil, fmt.Errorf("request error"))
+
+	response, resp, err := svc.UpdateIdentity(balanceID, body)
+
+	assert.Error(t, err)
+	assert.Nil(t, response)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_UpdateIdentity_ServerError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f"
+	body := blnkgo.UpdateBalanceIdentityRequest{IdentityID: "idt_3b63c8da-af29-4cc3-ad38-df17d87456e6"}
+	endpoint := fmt.Sprintf("balances/%s/identity", balanceID)
+	expectedResp := &http.Response{StatusCode: http.StatusInternalServerError}
+
+	mockClient.On("NewRequest", endpoint, http.MethodPut, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(expectedResp, fmt.Errorf("server error"))
+
+	response, resp, err := svc.UpdateIdentity(balanceID, body)
+
+	assert.Error(t, err)
+	assert.Nil(t, response)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestUpdateBalanceIdentityResponse_UnmarshalJSON(t *testing.T) {
+	payload := `{"message":"Balance identity updated successfully"}`
+
+	var response blnkgo.UpdateBalanceIdentityResponse
+	err := json.Unmarshal([]byte(payload), &response)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Balance identity updated successfully", response.Message)
+}


### PR DESCRIPTION
## Summary
- Adds `LedgerBalance.UpdateIdentity(balanceID, UpdateBalanceIdentityRequest)` calling `PUT /balances/{id}/identity`
- Introduces request/response types aligned with [update balance identity API reference](https://docs.blnkfinance.com/reference/update-balance-identity)
- Validates `balanceID` and `identity_id` client-side before sending the request
- Adds mocked unit tests plus JSON fixture decode test for the response payload
- Documents linking an identity to a balance in README

Closes #33

## Acceptance criteria
- [x] Add `LedgerBalance.UpdateIdentity` calling `/balances/{id}/identity`
- [x] Request/response Go types match reference fields
- [x] Client-side validation (if any) aligned with API rules
- [x] Unit test with mocked HTTP (follow existing `*_test.go` patterns)
- [x] Example or note in README / Go SDK docs

## Test plan
- [x] `go test ./... -run UpdateIdentity -v`
- [x] `go test ./...`