### PR TITLE
feat(balances): add LedgerBalance.CreateSnapshot (closes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,24 @@ if err != nil {
 fmt.Printf("Identity linked: %s\n", result.Message)
 ```
 
+### Creating Balance Snapshots
+
+Capture daily balance snapshots in batches. Optionally set `BatchSize` to control how many balances are processed per batch (server default is 1000):
+
+```go
+snapshotBody := blnkgo.CreateBalanceSnapshotRequest{
+    BatchSize: 500,
+}
+
+result, resp, err := client.LedgerBalance.CreateSnapshot(snapshotBody)
+if err != nil {
+    fmt.Printf("Error creating balance snapshot: %v\n", err)
+    return
+}
+
+fmt.Printf("Snapshot started: %s\n", result.Message)
+```
+
 ---
 
 ## 6. Recording Transactions

--- a/ledger_balance_snapshot.go
+++ b/ledger_balance_snapshot.go
@@ -1,0 +1,40 @@
+package blnkgo
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type CreateBalanceSnapshotRequest struct {
+	// BatchSize controls how many balances are processed per batch.
+	// Zero omits the query parameter and uses the server default (1000).
+	BatchSize int `json:"-"`
+}
+
+type CreateBalanceSnapshotResponse struct {
+	Message string `json:"message"`
+}
+
+func (s *LedgerBalanceService) CreateSnapshot(body CreateBalanceSnapshotRequest) (*CreateBalanceSnapshotResponse, *http.Response, error) {
+	if body.BatchSize < 0 {
+		return nil, nil, fmt.Errorf("invalid: batch_size must be positive")
+	}
+
+	endpoint := "balances-snapshots"
+	if body.BatchSize > 0 {
+		endpoint = fmt.Sprintf("balances-snapshots?batch_size=%d", body.BatchSize)
+	}
+
+	req, err := s.client.NewRequest(endpoint, http.MethodPost, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response := new(CreateBalanceSnapshotResponse)
+	resp, err := s.client.CallWithRetry(req, response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response, resp, nil
+}

--- a/ledger_balance_snapshot_test.go
+++ b/ledger_balance_snapshot_test.go
@@ -114,11 +114,17 @@ func TestLedgerBalanceService_CreateSnapshot_ServerError(t *testing.T) {
 }
 
 func TestCreateBalanceSnapshotResponse_UnmarshalJSON(t *testing.T) {
-	payload := `{"message":"Snapshotting in progress. should be completed shortly"}`
+	// Core v0.14.3 TakeBalanceSnapshots response: {"message":"Snapshotting in progress. should be completed shortly"}
+	payload := []byte(`{"message":"Snapshotting in progress. should be completed shortly"}`)
 
 	var response blnkgo.CreateBalanceSnapshotResponse
-	err := json.Unmarshal([]byte(payload), &response)
+	err := json.Unmarshal(payload, &response)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Snapshotting in progress. should be completed shortly", response.Message)
+
+	// Round-trip confirms struct tags match the API field name.
+	encoded, err := json.Marshal(response)
+	assert.NoError(t, err)
+	assert.JSONEq(t, string(payload), string(encoded))
 }

--- a/ledger_balance_snapshot_test.go
+++ b/ledger_balance_snapshot_test.go
@@ -1,0 +1,124 @@
+package blnkgo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLedgerBalanceService_CreateSnapshot_Success(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	body := blnkgo.CreateBalanceSnapshotRequest{BatchSize: 500}
+
+	expectedResponse := &blnkgo.CreateBalanceSnapshotResponse{
+		Message: "Snapshotting in progress. should be completed shortly",
+	}
+
+	mockClient.On("NewRequest", "balances-snapshots?batch_size=500", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		response := args.Get(1).(*blnkgo.CreateBalanceSnapshotResponse)
+		*response = *expectedResponse
+	})
+
+	response, resp, err := svc.CreateSnapshot(body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, response)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_CreateSnapshot_DefaultBatchSize(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	body := blnkgo.CreateBalanceSnapshotRequest{}
+
+	mockClient.On("NewRequest", "balances-snapshots", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, err := svc.CreateSnapshot(body)
+
+	assert.NoError(t, err)
+	mockClient.AssertCalled(t, "NewRequest", "balances-snapshots", http.MethodPost, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_CreateSnapshot_CorrectEndpoint(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	body := blnkgo.CreateBalanceSnapshotRequest{BatchSize: 250}
+
+	mockClient.On("NewRequest", "balances-snapshots?batch_size=250", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, _ = svc.CreateSnapshot(body)
+
+	mockClient.AssertCalled(t, "NewRequest", "balances-snapshots?batch_size=250", http.MethodPost, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_CreateSnapshot_InvalidBatchSize(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	body := blnkgo.CreateBalanceSnapshotRequest{BatchSize: -1}
+
+	response, resp, err := svc.CreateSnapshot(body)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "batch_size must be positive")
+	assert.Nil(t, response)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_CreateSnapshot_NewRequestError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	body := blnkgo.CreateBalanceSnapshotRequest{}
+
+	mockClient.On("NewRequest", "balances-snapshots", http.MethodPost, nil).Return(nil, fmt.Errorf("request error"))
+
+	response, resp, err := svc.CreateSnapshot(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, response)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_CreateSnapshot_ServerError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	body := blnkgo.CreateBalanceSnapshotRequest{}
+	expectedResp := &http.Response{StatusCode: http.StatusInternalServerError}
+
+	mockClient.On("NewRequest", "balances-snapshots", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(expectedResp, fmt.Errorf("server error"))
+
+	response, resp, err := svc.CreateSnapshot(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, response)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestCreateBalanceSnapshotResponse_UnmarshalJSON(t *testing.T) {
+	payload := `{"message":"Snapshotting in progress. should be completed shortly"}`
+
+	var response blnkgo.CreateBalanceSnapshotResponse
+	err := json.Unmarshal([]byte(payload), &response)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Snapshotting in progress. should be completed shortly", response.Message)
+}


### PR DESCRIPTION
## Summary
- Add `LedgerBalance.CreateSnapshot` for `POST /balances-snapshots` with optional `batch_size` query parameter
- Add `CreateBalanceSnapshotRequest` and `CreateBalanceSnapshotResponse` types aligned with Blnk Core v0.14.3
- Add mocked HTTP unit tests and JSON fixture decode coverage
- Document usage in README

## Test plan
- [x] `go test ./...`
- [x] Verify `POST /balances-snapshots` against a running Blnk instance (default and custom `batch_size`)
- [x] Confirm response message: `Snapshotting in progress. should be completed shortly`

Closes #34