### PR TITLE
Add Transaction.GetLineage (GET /transactions/{id}/lineage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,23 @@ fmt.Printf("Bulk batch %s: %d transactions (%s)\n",
     bulkResult.BatchID, bulkResult.TransactionCount, bulkResult.Status)
 ```
 
+### Viewing Transaction Lineage
+
+For transactions involving lineage-enabled balances, retrieve the provider fund allocation and internal shadow transactions:
+
+```go
+lineage, resp, err := client.Transaction.GetLineage(newTransaction.TransactionID)
+if err != nil {
+    fmt.Printf("Error fetching transaction lineage: %v\n", err)
+    return
+}
+
+fmt.Printf("Transaction Lineage: %+v\n", lineage)
+for _, alloc := range lineage.FundAllocation {
+    fmt.Printf("Provider %s allocated %s\n", alloc.Provider, alloc.Amount.String())
+}
+```
+
 ---
 
 ## 7. Advanced Features

--- a/integration/issue36_test.go
+++ b/integration/issue36_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+// Integration tests for issue #36 — Transaction.GetLineage (GET /transactions/{id}/lineage).
+// Requires Blnk Core running at http://localhost:5001 (docker compose up in blnk/).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue36
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newClientIssue36(t *testing.T) *blnkgo.Client {
+	t.Helper()
+	u, err := url.Parse("http://localhost:5001/")
+	require.NoError(t, err)
+	return blnkgo.NewClient(u, nil, blnkgo.WithTimeout(15*time.Second), blnkgo.WithRetry(2))
+}
+
+func TestIssue36_GetTransactionLineage(t *testing.T) {
+	client := newClientIssue36(t)
+	ref := fmt.Sprintf("lineage-%d", time.Now().UnixNano())
+
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      500,
+			Reference:   ref,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Destination: "@Recipient",
+			Description: "Lineage integration tx",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		_, getResp, getErr := client.Transaction.Get(txn.TransactionID)
+		if getErr == nil && getResp.StatusCode == http.StatusOK {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, getErr, "transaction not available before lineage call")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	lineage, resp, err := client.Transaction.GetLineage(txn.TransactionID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, txn.TransactionID, lineage.TransactionID)
+}
+
+func TestIssue36_GetTransactionLineage_EmptyID(t *testing.T) {
+	client := newClientIssue36(t)
+
+	lineage, resp, err := client.Transaction.GetLineage("")
+	require.Error(t, err)
+	require.Nil(t, lineage)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "transactionID is required")
+}

--- a/transaction_lineage.go
+++ b/transaction_lineage.go
@@ -1,0 +1,62 @@
+package blnkgo
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+)
+
+// LineageFundAllocation is the per-provider fund allocation for a debit transaction
+// from a lineage-enabled balance.
+type LineageFundAllocation struct {
+	Provider string   `json:"provider"`
+	Amount   *big.Int `json:"amount"`
+}
+
+// TransactionLineage is the fund lineage view for a transaction, including
+// provider-level fund allocation and internal shadow transactions.
+type TransactionLineage struct {
+	TransactionID      string                  `json:"transaction_id"`
+	FundAllocation     []LineageFundAllocation `json:"fund_allocation,omitempty"`
+	ShadowTransactions []Transaction           `json:"shadow_transactions"`
+}
+
+func (a *LineageFundAllocation) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Provider string          `json:"provider"`
+		Amount   json.RawMessage `json:"amount"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	amount, err := unmarshalBigIntJSON(raw.Amount)
+	if err != nil {
+		return err
+	}
+
+	a.Provider = raw.Provider
+	a.Amount = amount
+	return nil
+}
+
+func (s *TransactionService) GetLineage(transactionID string) (*TransactionLineage, *http.Response, error) {
+	if transactionID == "" {
+		return nil, nil, fmt.Errorf("transactionID is required")
+	}
+
+	u := fmt.Sprintf("transactions/%s/lineage", transactionID)
+	req, err := s.client.NewRequest(u, http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lineage := new(TransactionLineage)
+	resp, err := s.client.CallWithRetry(req, lineage)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return lineage, resp, nil
+}

--- a/transaction_lineage_test.go
+++ b/transaction_lineage_test.go
@@ -1,0 +1,186 @@
+package blnkgo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestTransactionLineage_UnmarshalJSON verifies TransactionLineage decodes the API
+// response contract from docs.blnkfinance.com/reference/get-transaction-lineage.
+func TestTransactionLineage_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name: "docs example with string amounts",
+			payload: `{
+				"transaction_id": "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad",
+				"fund_allocation": [
+					{ "provider": "stripe", "amount": "2500" }
+				],
+				"shadow_transactions": [
+					{
+						"transaction_id": "txn_shadow_123",
+						"reference": "ref_002_release_stripe_0",
+						"amount": 25,
+						"precision": 100,
+						"currency": "USD",
+						"status": "APPLIED"
+					}
+				]
+			}`,
+		},
+		{
+			name: "core serialization with numeric amounts",
+			payload: `{
+				"transaction_id": "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad",
+				"fund_allocation": [
+					{ "provider": "stripe", "amount": 2500 },
+					{ "provider": "paypal", "amount": 1000 }
+				],
+				"shadow_transactions": []
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var lineage blnkgo.TransactionLineage
+			err := json.Unmarshal([]byte(tt.payload), &lineage)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad", lineage.TransactionID)
+			assert.NotEmpty(t, lineage.FundAllocation)
+			assert.Equal(t, "stripe", lineage.FundAllocation[0].Provider)
+			assert.Equal(t, 0, big.NewInt(2500).Cmp(lineage.FundAllocation[0].Amount))
+
+			if tt.name == "docs example with string amounts" {
+				assert.Len(t, lineage.ShadowTransactions, 1)
+				shadow := lineage.ShadowTransactions[0]
+				assert.Equal(t, "txn_shadow_123", shadow.TransactionID)
+				assert.Equal(t, "ref_002_release_stripe_0", shadow.Reference)
+				assert.Equal(t, "USD", shadow.Currency)
+				assert.Equal(t, blnkgo.PryTransactionStatusApplied, shadow.Status)
+				assert.Equal(t, float64(25), shadow.Amount)
+			} else {
+				assert.Empty(t, lineage.ShadowTransactions)
+				assert.Len(t, lineage.FundAllocation, 2)
+				assert.Equal(t, "paypal", lineage.FundAllocation[1].Provider)
+				assert.Equal(t, 0, big.NewInt(1000).Cmp(lineage.FundAllocation[1].Amount))
+			}
+		})
+	}
+}
+
+func TestTransactionService_GetLineage_Success(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	transactionID := "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+
+	expectedResponse := &blnkgo.TransactionLineage{
+		TransactionID: transactionID,
+		FundAllocation: []blnkgo.LineageFundAllocation{
+			{
+				Provider: "stripe",
+				Amount:   big.NewInt(2500),
+			},
+		},
+		ShadowTransactions: []blnkgo.Transaction{
+			{
+				TransactionID: "txn_shadow_123",
+				ParentTransaction: blnkgo.ParentTransaction{
+					Reference: "ref_002_release_stripe_0",
+					Currency:  "USD",
+					Status:    blnkgo.PryTransactionStatusApplied,
+				},
+			},
+		},
+	}
+
+	endpoint := fmt.Sprintf("transactions/%s/lineage", transactionID)
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		lineage := args.Get(1).(*blnkgo.TransactionLineage)
+		*lineage = *expectedResponse
+	})
+
+	lineage, resp, err := svc.GetLineage(transactionID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, lineage)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetLineage_CorrectEndpoint(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	transactionID := "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+	endpoint := fmt.Sprintf("transactions/%s/lineage", transactionID)
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, _ = svc.GetLineage(transactionID)
+
+	mockClient.AssertCalled(t, "NewRequest", endpoint, http.MethodGet, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetLineage_EmptyID(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	lineage, resp, err := svc.GetLineage("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "transactionID is required")
+	assert.Nil(t, lineage)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetLineage_NewRequestError(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	transactionID := "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+	endpoint := fmt.Sprintf("transactions/%s/lineage", transactionID)
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(nil, fmt.Errorf("request error"))
+
+	lineage, resp, err := svc.GetLineage(transactionID)
+
+	assert.Error(t, err)
+	assert.Nil(t, lineage)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetLineage_ServerError(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	transactionID := "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+	endpoint := fmt.Sprintf("transactions/%s/lineage", transactionID)
+	expectedResp := &http.Response{StatusCode: http.StatusInternalServerError}
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(expectedResp, fmt.Errorf("server error"))
+
+	lineage, resp, err := svc.GetLineage(transactionID)
+
+	assert.Error(t, err)
+	assert.Nil(t, lineage)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- Add `Transaction.GetLineage` for `GET /transactions/{id}/lineage`
- Types, tests, README

Closes #36

## Test plan
- [x] `go test ./...`
- [x] integration tests against local Core (:5001) if available

Made with [Cursor](https://cursor.com)