### PR TITLE
Add Transaction.GetByReference (GET /transactions/reference/{reference})

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,20 @@ fmt.Printf("Bulk batch %s: %d transactions (%s)\n",
     bulkResult.BatchID, bulkResult.TransactionCount, bulkResult.Status)
 ```
 
+### Getting a Transaction by Reference
+
+Look up a transaction using its unique reference string:
+
+```go
+transaction, resp, err := client.Transaction.GetByReference("ref_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad")
+if err != nil {
+    fmt.Printf("Error fetching transaction by reference: %v\n", err)
+    return
+}
+
+fmt.Printf("Transaction %s: %+v\n", transaction.TransactionID, transaction)
+```
+
 ---
 
 ## 7. Advanced Features

--- a/integration/issue37_test.go
+++ b/integration/issue37_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+// Integration tests for issue #37 — Transaction.GetByReference (GET /transactions/reference/{reference}).
+// Requires Blnk Core running at http://localhost:5001 (docker compose up in blnk/).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue37
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newClientIssue37(t *testing.T) *blnkgo.Client {
+	t.Helper()
+	u, err := url.Parse("http://localhost:5001/")
+	require.NoError(t, err)
+	return blnkgo.NewClient(u, nil, blnkgo.WithTimeout(15*time.Second), blnkgo.WithRetry(2))
+}
+
+func TestIssue37_GetTransactionByReference(t *testing.T) {
+	client := newClientIssue37(t)
+	ref := fmt.Sprintf("ref-by-ref-%d", time.Now().UnixNano())
+
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      500,
+			Reference:   ref,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Destination: "@Recipient",
+			Description: "GetByReference integration tx",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		_, getResp, getErr := client.Transaction.Get(txn.TransactionID)
+		if getErr == nil && getResp.StatusCode == http.StatusOK {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, getErr, "transaction not available before GetByReference call")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	byRef, resp, err := client.Transaction.GetByReference(ref)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, txn.TransactionID, byRef.TransactionID)
+	require.Equal(t, ref, byRef.Reference)
+	require.Equal(t, "USD", byRef.Currency)
+}
+
+func TestIssue37_GetTransactionByReference_EmptyReference(t *testing.T) {
+	client := newClientIssue37(t)
+
+	transaction, resp, err := client.Transaction.GetByReference("")
+	require.Error(t, err)
+	require.Nil(t, transaction)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "reference is required")
+}

--- a/transaction.go
+++ b/transaction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -170,7 +171,7 @@ func (s *TransactionService) GetByReference(reference string) (*Transaction, *ht
 		return nil, nil, fmt.Errorf("reference is required")
 	}
 
-	u := fmt.Sprintf("transactions/reference/%s", reference)
+	u := fmt.Sprintf("transactions/reference/%s", url.PathEscape(reference))
 	req, err := s.client.NewRequest(u, http.MethodGet, nil)
 	if err != nil {
 		return nil, nil, err

--- a/transaction.go
+++ b/transaction.go
@@ -165,6 +165,26 @@ func (s *TransactionService) Get(transactionID string) (*Transaction, *http.Resp
 	return transaction, resp, nil
 }
 
+func (s *TransactionService) GetByReference(reference string) (*Transaction, *http.Response, error) {
+	if reference == "" {
+		return nil, nil, fmt.Errorf("reference is required")
+	}
+
+	u := fmt.Sprintf("transactions/reference/%s", reference)
+	req, err := s.client.NewRequest(u, http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	transaction := new(Transaction)
+	resp, err := s.client.CallWithRetry(req, transaction)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return transaction, resp, nil
+}
+
 func (s *TransactionService) Filter(params FilterParams) (*FilterResponse, *http.Response, error) {
 	req, err := s.client.NewRequest("transactions/filter", http.MethodPost, params)
 	if err != nil {

--- a/transaction_get_by_reference_test.go
+++ b/transaction_get_by_reference_test.go
@@ -1,0 +1,113 @@
+package blnkgo_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestTransactionService_GetByReference_Success(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	reference := "ref_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+	fixedTime := time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC)
+
+	expectedResponse := &blnkgo.Transaction{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      1000,
+			Reference:   reference,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Destination: "@Recipient",
+			Status:      blnkgo.PryTransactionStatusApplied,
+			Description: "Test Transaction",
+		},
+		TransactionID: "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad",
+		CreatedAt:     fixedTime,
+	}
+
+	endpoint := fmt.Sprintf("transactions/reference/%s", reference)
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		transaction := args.Get(1).(*blnkgo.Transaction)
+		*transaction = *expectedResponse
+	})
+
+	transaction, resp, err := svc.GetByReference(reference)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, transaction)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetByReference_CorrectEndpoint(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	reference := "ref_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+	endpoint := fmt.Sprintf("transactions/reference/%s", reference)
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, _ = svc.GetByReference(reference)
+
+	mockClient.AssertCalled(t, "NewRequest", endpoint, http.MethodGet, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetByReference_EmptyReference(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	transaction, resp, err := svc.GetByReference("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reference is required")
+	assert.Nil(t, transaction)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetByReference_NewRequestError(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	reference := "ref_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+	endpoint := fmt.Sprintf("transactions/reference/%s", reference)
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(nil, fmt.Errorf("request error"))
+
+	transaction, resp, err := svc.GetByReference(reference)
+
+	assert.Error(t, err)
+	assert.Nil(t, transaction)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetByReference_ServerError(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	reference := "ref_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+	endpoint := fmt.Sprintf("transactions/reference/%s", reference)
+	expectedResp := &http.Response{StatusCode: http.StatusInternalServerError}
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(expectedResp, fmt.Errorf("server error"))
+
+	transaction, resp, err := svc.GetByReference(reference)
+
+	assert.Error(t, err)
+	assert.Nil(t, transaction)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}

--- a/transaction_get_by_reference_test.go
+++ b/transaction_get_by_reference_test.go
@@ -3,6 +3,7 @@ package blnkgo_test
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -46,6 +47,22 @@ func TestTransactionService_GetByReference_Success(t *testing.T) {
 	assert.Equal(t, expectedResponse, transaction)
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetByReference_PathEscapesReference(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	reference := "ref/with space?query#hash%25"
+	endpoint := fmt.Sprintf("transactions/reference/%s", url.PathEscape(reference))
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, _ = svc.GetByReference(reference)
+
+	mockClient.AssertCalled(t, "NewRequest", endpoint, http.MethodGet, nil)
 	mockClient.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary
- Add `Transaction.GetByReference` for `GET /transactions/reference/{reference}`

Closes #37

## Test plan
- [x] `go test ./...`
- [x] integration tests against local Core (:5001)

Made with [Cursor](https://cursor.com)