### PR TITLE
Add search identities resource type and Transaction.GetLineage (#73, #36)

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -99,6 +99,7 @@ const (
 	Ledgers      ResourceType = "ledgers"
 	Transactions ResourceType = "transactions"
 	Balances     ResourceType = "balances"
+	Identities   ResourceType = "identities"
 )
 
 type CriteriaField string

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,34 @@
+# Integration tests
+
+Requires Blnk Core running locally and an API key.
+
+```bash
+cd ../blnk && docker compose up -d
+export BLNK_API_KEY=your_master_or_api_key
+# optional: export BLNK_BASE_URL=http://localhost:5001/
+```
+
+## Run
+
+```bash
+# one issue
+go test -tags=integration -v ./integration/... -run Issue73
+go test -tags=integration -v ./integration/... -run Issue36
+
+# all integration tests
+go test -tags=integration -v ./integration/...
+```
+
+## Core version notes
+
+| Issue | Core version | Why |
+|-------|--------------|-----|
+| #73 search identities | 0.14.x+ | Not 0.15-only |
+| #36 transaction lineage | 0.14.x+ | Not 0.15-only |
+| 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |
+
+If `BLNK_API_KEY` is unset, integration tests skip.
+
+## Postman
+
+Manual request seeds live in `manual/postman/`. Use those after integration tests pass.

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationAPIKey(t *testing.T) string {
+	t.Helper()
+	key := os.Getenv("BLNK_API_KEY")
+	if key == "" {
+		t.Skip("BLNK_API_KEY is not set; skipping integration test against Blnk Core")
+	}
+	return key
+}
+
+func integrationBaseURL(t *testing.T) *url.URL {
+	t.Helper()
+	raw := os.Getenv("BLNK_BASE_URL")
+	if raw == "" {
+		raw = "http://localhost:5001/"
+	}
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func newIntegrationClient(t *testing.T) *blnkgo.Client {
+	t.Helper()
+	apiKey := integrationAPIKey(t)
+	u := integrationBaseURL(t)
+	return blnkgo.NewClient(u, &apiKey, blnkgo.WithTimeout(15*time.Second), blnkgo.WithRetry(2))
+}

--- a/integration/issue35_test.go
+++ b/integration/issue35_test.go
@@ -9,7 +9,6 @@ package integration
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"testing"
 	"time"
 
@@ -18,10 +17,7 @@ import (
 )
 
 func newClientIssue35(t *testing.T) *blnkgo.Client {
-	t.Helper()
-	u, err := url.Parse("http://localhost:5001/")
-	require.NoError(t, err)
-	return blnkgo.NewClient(u, nil, blnkgo.WithTimeout(15*time.Second), blnkgo.WithRetry(2))
+	return newIntegrationClient(t)
 }
 
 func TestIssue35_CreateBulkTransactions(t *testing.T) {

--- a/integration/issue36_test.go
+++ b/integration/issue36_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+// Integration tests for issue #36 — Transaction.GetLineage (GET /transactions/{id}/lineage).
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+// Works on Core 0.14.x+ (fund lineage); does not require 0.15-only features.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue36
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newClientIssue36(t *testing.T) *blnkgo.Client {
+	return newIntegrationClient(t)
+}
+
+func TestIssue36_GetTransactionLineage(t *testing.T) {
+	client := newClientIssue36(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	// Seed real balances; @FundingPool/@Recipient internal references are not
+	// reliably resolvable across Core setups, so use concrete balance IDs.
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "Lineage Test " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	source, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	dest, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// skip_queue applies synchronously so the transaction is immediately retrievable.
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      100,
+			Reference:   "lineage-" + suffix,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      source.BalanceID,
+			Destination: dest.BalanceID,
+			SkipQueue:   true,
+			Description: "GetLineage integration tx",
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+
+	lineage, resp, err := client.Transaction.GetLineage(txn.TransactionID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, txn.TransactionID, lineage.TransactionID)
+}
+
+func TestIssue36_GetTransactionLineage_EmptyID(t *testing.T) {
+	client := newClientIssue36(t)
+
+	lineage, resp, err := client.Transaction.GetLineage("")
+	require.Error(t, err)
+	require.Nil(t, lineage)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "transactionID is required")
+}

--- a/integration/issue37_test.go
+++ b/integration/issue37_test.go
@@ -9,7 +9,6 @@ package integration
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"testing"
 	"time"
 
@@ -18,10 +17,7 @@ import (
 )
 
 func newClientIssue37(t *testing.T) *blnkgo.Client {
-	t.Helper()
-	u, err := url.Parse("http://localhost:5001/")
-	require.NoError(t, err)
-	return blnkgo.NewClient(u, nil, blnkgo.WithTimeout(15*time.Second), blnkgo.WithRetry(2))
+	return newIntegrationClient(t)
 }
 
 func TestIssue37_GetTransactionByReference(t *testing.T) {

--- a/integration/issue38_test.go
+++ b/integration/issue38_test.go
@@ -9,7 +9,6 @@ package integration
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"testing"
 	"time"
 
@@ -18,10 +17,7 @@ import (
 )
 
 func newClientIssue38(t *testing.T) *blnkgo.Client {
-	t.Helper()
-	u, err := url.Parse("http://localhost:5001/")
-	require.NoError(t, err)
-	return blnkgo.NewClient(u, nil, blnkgo.WithTimeout(15*time.Second), blnkgo.WithRetry(2))
+	return newIntegrationClient(t)
 }
 
 func createInflightTxnIssue38(t *testing.T, client *blnkgo.Client, ref string, amount float64) string {

--- a/integration/issue39_test.go
+++ b/integration/issue39_test.go
@@ -9,7 +9,6 @@ package integration
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"testing"
 	"time"
 
@@ -18,10 +17,7 @@ import (
 )
 
 func newClientIssue39(t *testing.T) *blnkgo.Client {
-	t.Helper()
-	u, err := url.Parse("http://localhost:5001/")
-	require.NoError(t, err)
-	return blnkgo.NewClient(u, nil, blnkgo.WithTimeout(15*time.Second), blnkgo.WithRetry(2))
+	return newIntegrationClient(t)
 }
 
 func createInflightTxnIssue39(t *testing.T, client *blnkgo.Client, ref string, amount float64) string {

--- a/integration/issue73_test.go
+++ b/integration/issue73_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+// Integration tests for issue #73 — Search.SearchDocument identities ResourceType.
+// Requires Blnk Core running at http://localhost:5001 (0.14.x+; search/identities is not 0.15-only).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue73
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newClientIssue73(t *testing.T) *blnkgo.Client {
+	return newIntegrationClient(t)
+}
+
+func TestIssue73_SearchIdentities(t *testing.T) {
+	client := newClientIssue73(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	email := fmt.Sprintf("search-identities-%s@example.com", suffix)
+	dob := time.Date(1990, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	identity, resp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Search",
+		LastName:     "Test",
+		EmailAddress: email,
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+		DOB:          &dob,
+		Gender:       "Male",
+		Nationality:  "American",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, identity.IdentityId)
+
+	// Core returns 201 for POST /search/{resource}; accept any 2xx.
+	deadline := time.Now().Add(20 * time.Second)
+	var searchResp *blnkgo.SearchResponse
+	for {
+		searchResp, resp, err = client.Search.SearchDocument(blnkgo.SearchParams{
+			Q:       email,
+			QueryBy: "email_address",
+			Page:    1,
+			PerPage: 10,
+		}, blnkgo.Identities)
+		if err == nil && resp.StatusCode < 300 && searchResp.Found > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "search identities timed out waiting for index")
+			require.Less(t, resp.StatusCode, 300, "expected 2xx from search/identities")
+			require.Greater(t, searchResp.Found, 0, "expected indexed identity in search results")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	require.Less(t, resp.StatusCode, 300)
+	require.Greater(t, searchResp.Found, 0)
+}

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,0 +1,37 @@
+# Postman — Go SDK local Core tests
+
+Import these two files into Postman (one-time):
+
+1. **Collection:** `go-sdk-local-core-tests.postman_collection.json`
+2. **Environment:** `go-sdk-local-core.postman_environment.json`
+
+## Run in Postman
+
+1. Select environment **Blnk Go SDK — local Core 0.14.5**
+2. Open collection **Blnk Go SDK — Local Core Tests**
+3. Click **Run** (Collection Runner)
+4. Run all — variables chain automatically
+
+## Folders
+
+| Folder | What it tests | Core version |
+|--------|---------------|--------------|
+| **Issue #73 — Search identities** | `POST /search/identities` | 0.14.5+ |
+| **Issue #36 — Transaction GetLineage** | `GET /transactions/{id}/lineage` | 0.14.5+ |
+
+## CLI (same tests, no Postman UI)
+
+```bash
+cd blnk-go
+npx newman run postman/go-sdk-local-core-tests.postman_collection.json \
+  -e postman/go-sdk-local-core.postman_environment.json
+```
+
+## Prerequisites
+
+```bash
+cd ../blnk && docker compose up -d
+curl http://localhost:5001/health   # should return {"status":"UP"}
+```
+
+API key defaults to `blnk-local-dev-secret-change-me` from `blnk/blnk.json`.

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -1,0 +1,301 @@
+{
+  "info": {
+    "name": "Blnk Go SDK — Local Core Tests",
+    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "blnk_base_url",
+      "value": "http://localhost:5001"
+    },
+    {
+      "key": "blnk_api_key",
+      "value": "blnk-local-dev-secret-change-me"
+    },
+    {
+      "key": "test_email",
+      "value": ""
+    },
+    {
+      "key": "ledger_id",
+      "value": ""
+    },
+    {
+      "key": "source_balance_id",
+      "value": ""
+    },
+    {
+      "key": "dest_balance_id",
+      "value": ""
+    },
+    {
+      "key": "transaction_id",
+      "value": ""
+    }
+  ],
+  "item": [
+    {
+      "name": "Issue #73 — Search identities",
+      "item": [
+        {
+          "name": "1. Create identity (seed)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const email = `go-sdk-73-${Date.now()}@example.com`;",
+                  "pm.collectionVariables.set('test_email', email);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.test('identity_id returned', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.identity_id).to.be.a('string').and.not.empty;",
+                  "    pm.collectionVariables.set('identity_id', json.identity_id);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identity_type\": \"individual\",\n  \"first_name\": \"GoSDK\",\n  \"last_name\": \"SearchTest\",\n  \"email_address\": \"{{test_email}}\",\n  \"phone_number\": \"1234567890\",\n  \"category\": \"customer\",\n  \"street\": \"123 Main St\",\n  \"country\": \"USA\",\n  \"state\": \"CA\",\n  \"post_code\": \"90001\",\n  \"city\": \"Los Angeles\",\n  \"dob\": \"1990-01-15T00:00:00Z\",\n  \"gender\": \"Male\",\n  \"nationality\": \"American\"\n}"
+            },
+            "url": "{{blnk_base_url}}/identities",
+            "description": "Seeds an identity for search. Email is auto-generated per run."
+          }
+        },
+        {
+          "name": "2. Search identities",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 2xx (Core may return 201)', function () {",
+                  "    pm.expect(pm.response.code).to.be.within(200, 299);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "const retries = parseInt(pm.collectionVariables.get('search_retries') || '0', 10);",
+                  "",
+                  "if (json.found < 1 && retries < 20) {",
+                  "    pm.collectionVariables.set('search_retries', String(retries + 1));",
+                  "    setTimeout(function () {}, 500);",
+                  "    postman.setNextRequest('2. Search identities');",
+                  "} else {",
+                  "    pm.collectionVariables.unset('search_retries');",
+                  "    pm.test('found >= 1 for seeded email', function () {",
+                  "        pm.expect(json.found).to.be.at.least(1);",
+                  "    });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"q\": \"{{test_email}}\",\n  \"query_by\": \"email_address\",\n  \"page\": 1,\n  \"per_page\": 10\n}"
+            },
+            "url": "{{blnk_base_url}}/search/identities",
+            "description": "Go SDK: SearchDocument(params, blnkgo.Identities)"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Issue #36 — Transaction GetLineage",
+      "item": [
+        {
+          "name": "1. Create ledger",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('ledger_id', json.ledger_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Go SDK Lineage Test\"\n}"
+            },
+            "url": "{{blnk_base_url}}/ledgers"
+          }
+        },
+        {
+          "name": "2. Create source balance",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('source_balance_id', json.balance_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ledger_id\": \"{{ledger_id}}\",\n  \"currency\": \"USD\"\n}"
+            },
+            "url": "{{blnk_base_url}}/balances"
+          }
+        },
+        {
+          "name": "3. Create destination balance",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('dest_balance_id', json.balance_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ledger_id\": \"{{ledger_id}}\",\n  \"currency\": \"USD\"\n}"
+            },
+            "url": "{{blnk_base_url}}/balances"
+          }
+        },
+        {
+          "name": "4. Create transaction (skip_queue)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('tx_reference', `lineage-${Date.now()}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.expect(json.transaction_id).to.be.a('string').and.not.empty;",
+                  "pm.collectionVariables.set('transaction_id', json.transaction_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 100,\n  \"reference\": \"{{tx_reference}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"{{source_balance_id}}\",\n  \"destination\": \"{{dest_balance_id}}\",\n  \"skip_queue\": true,\n  \"allow_overdraft\": true,\n  \"description\": \"Go SDK GetLineage test\"\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions"
+          }
+        },
+        {
+          "name": "5. Get transaction lineage",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('transaction_id matches', function () {",
+                  "    const json = pm.response.json();",
+                  "    const expected = pm.collectionVariables.get('transaction_id');",
+                  "    pm.expect(json.transaction_id).to.eql(expected);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
+            ],
+            "url": "{{blnk_base_url}}/transactions/{{transaction_id}}/lineage",
+            "description": "Go SDK: Transaction.GetLineage(transactionID)"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/postman/go-sdk-local-core.postman_environment.json
+++ b/postman/go-sdk-local-core.postman_environment.json
@@ -1,0 +1,18 @@
+{
+  "name": "Blnk Go SDK — local Core 0.14.5",
+  "values": [
+    {
+      "key": "blnk_base_url",
+      "value": "http://localhost:5001",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "blnk_api_key",
+      "value": "blnk-local-dev-secret-change-me",
+      "type": "secret",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/search_test.go
+++ b/search_test.go
@@ -80,6 +80,34 @@ func TestSearchService_SearchDocument_Success(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestSearchService_SearchDocument_IdentitiesResource(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	body := blnkgo.SearchParams{
+		Q:       "john.doe@example.com",
+		QueryBy: "email_address",
+		Page:    1,
+		PerPage: 10,
+	}
+
+	mockClient.On("NewRequest", "search/identities", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		searchResponse := args.Get(1).(*blnkgo.SearchResponse)
+		*searchResponse = blnkgo.SearchResponse{Found: 1, Page: 1}
+	})
+
+	searchResponse, resp, err := svc.SearchDocument(body, blnkgo.Identities)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, searchResponse)
+	assert.Equal(t, 1, searchResponse.Found)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
 func TestSearchService_SearchDocument_EmptyRequest(t *testing.T) {
 	mockClient, svc := setupSearchService()
 	body := blnkgo.SearchParams{}

--- a/transaction_lineage.go
+++ b/transaction_lineage.go
@@ -1,0 +1,56 @@
+package blnkgo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// TransactionLineage is the fund lineage view for a transaction, including
+// fund allocation metadata and any shadow transactions created for lineage tracking.
+type TransactionLineage struct {
+	TransactionID      string                   `json:"transaction_id"`
+	FundAllocation     []map[string]interface{} `json:"fund_allocation,omitempty"`
+	ShadowTransactions []map[string]interface{} `json:"shadow_transactions"`
+}
+
+func (t *TransactionLineage) UnmarshalJSON(data []byte) error {
+	type alias TransactionLineage
+	aux := &struct {
+		ShadowTransactions json.RawMessage `json:"shadow_transactions"`
+		*alias
+	}{
+		alias: (*alias)(t),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if len(aux.ShadowTransactions) == 0 || string(aux.ShadowTransactions) == "null" {
+		t.ShadowTransactions = nil
+		return nil
+	}
+
+	return json.Unmarshal(aux.ShadowTransactions, &t.ShadowTransactions)
+}
+
+func (s *TransactionService) GetLineage(transactionID string) (*TransactionLineage, *http.Response, error) {
+	if transactionID == "" {
+		return nil, nil, fmt.Errorf("transactionID is required")
+	}
+
+	u := fmt.Sprintf("transactions/%s/lineage", transactionID)
+	req, err := s.client.NewRequest(u, http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lineage := new(TransactionLineage)
+	resp, err := s.client.CallWithRetry(req, lineage)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return lineage, resp, nil
+}

--- a/transaction_lineage_test.go
+++ b/transaction_lineage_test.go
@@ -1,0 +1,137 @@
+package blnkgo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestTransactionLineage_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name: "docs example with empty shadow transactions",
+			payload: `{
+				"transaction_id": "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad",
+				"shadow_transactions": []
+			}`,
+		},
+		{
+			name: "null shadow transactions",
+			payload: `{
+				"transaction_id": "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad",
+				"shadow_transactions": null
+			}`,
+		},
+		{
+			name: "fund allocation with shadow transactions",
+			payload: `{
+				"transaction_id": "txn_main_123",
+				"fund_allocation": [{"provider": "stripe", "amount": "1000"}],
+				"shadow_transactions": [{
+					"transaction_id": "txn_shadow_1",
+					"reference": "shadow-ref",
+					"status": "APPLIED",
+					"precise_amount": "1000"
+				}]
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var lineage blnkgo.TransactionLineage
+			err := json.Unmarshal([]byte(tt.payload), &lineage)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, lineage.TransactionID)
+			if tt.name == "fund allocation with shadow transactions" {
+				assert.Len(t, lineage.FundAllocation, 1)
+				assert.Len(t, lineage.ShadowTransactions, 1)
+				assert.Equal(t, "txn_shadow_1", lineage.ShadowTransactions[0]["transaction_id"])
+			}
+		})
+	}
+}
+
+func TestTransactionService_GetLineage_Success(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	transactionID := "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+
+	expectedResponse := &blnkgo.TransactionLineage{
+		TransactionID: transactionID,
+		FundAllocation: []map[string]interface{}{
+			{"provider": "stripe", "amount": "1000"},
+		},
+	}
+
+	endpoint := fmt.Sprintf("transactions/%s/lineage", transactionID)
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		lineage := args.Get(1).(*blnkgo.TransactionLineage)
+		*lineage = *expectedResponse
+	})
+
+	lineage, resp, err := svc.GetLineage(transactionID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, lineage)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetLineage_CorrectEndpoint(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	transactionID := "txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad"
+	endpoint := fmt.Sprintf("transactions/%s/lineage", transactionID)
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, _ = svc.GetLineage(transactionID)
+
+	mockClient.AssertCalled(t, "NewRequest", endpoint, http.MethodGet, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetLineage_EmptyID(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	lineage, resp, err := svc.GetLineage("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "transactionID is required")
+	assert.Nil(t, lineage)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_GetLineage_ServerError(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	transactionID := "txn_nonexistent"
+	endpoint := fmt.Sprintf("transactions/%s/lineage", transactionID)
+	expectedResp := &http.Response{StatusCode: http.StatusNotFound}
+
+	mockClient.On("NewRequest", endpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(expectedResp, fmt.Errorf("not found"))
+
+	lineage, resp, err := svc.GetLineage(transactionID)
+
+	assert.Error(t, err)
+	assert.Nil(t, lineage)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- **#73** — Add `blnkgo.Identities` search resource type for `POST /search/identities`
- **#36** — Add `Transaction.GetLineage` for `GET /transactions/{id}/lineage`
- Shared integration test helper (`BLNK_API_KEY` + `BLNK_BASE_URL`)
- Postman collection for local Core 0.14.5 click-run verification

## Test plan
- [x] `go test ./...`
- [x] `BLNK_API_KEY=... go test -tags=integration ./integration/... -run 'Issue73|Issue36'`
- [x] Newman: `npx newman run postman/go-sdk-local-core-tests.postman_collection.json -e postman/go-sdk-local-core.postman_environment.json`
- [x] Postman collection **Blnk Go SDK — Local Core Tests** in Blnk workspace (manual run)