### PR TITLE
Add Transaction.RecoverQueue (POST /transactions/recover) (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,22 @@ fmt.Printf("Bulk batch %s: %d transactions (%s)\n",
     bulkResult.BatchID, bulkResult.TransactionCount, bulkResult.Status)
 ```
 
+### Recovering Stuck Queued Transactions
+
+Manually trigger recovery of transactions stuck in the queue (`POST /transactions/recover`). Optionally pass a `threshold` duration (e.g. `5m`, `1h`):
+
+```go
+result, resp, err := client.Transaction.RecoverQueue(blnkgo.RecoverQueueRequest{
+    Threshold: "5m",
+})
+if err != nil {
+    fmt.Printf("Error recovering queue: %v\n", err)
+    return
+}
+
+fmt.Printf("Recovered %d transactions (threshold %s)\n", result.Recovered, result.Threshold)
+```
+
 ### Getting a Transaction by Reference
 
 Look up a transaction using its unique reference string:

--- a/integration/README.md
+++ b/integration/README.md
@@ -12,17 +12,27 @@ export BLNK_API_KEY=your_master_or_api_key
 
 ```bash
 # one issue
+go test -tags=integration -v ./integration/... -run Issue40
 go test -tags=integration -v ./integration/... -run Issue73
 go test -tags=integration -v ./integration/... -run Issue36
 
 # all integration tests
-go test -tags=integration -v ./integration/...
+go test -tags=integration -v ./integration/... 
 ```
+
+## Issue #40 — RecoverQueue workflow
+
+1. Start Core 0.14.5: `cd ../blnk && docker compose up -d`
+2. Export API key: `export BLNK_API_KEY=blnk-local-dev-secret-change-me`
+3. Unit tests: `go test ./... -run RecoverQueue`
+4. Integration: `go test -tags=integration -v ./integration/... -run Issue40`
+5. Postman: run folder **Issue #40 — RecoverQueue** in `postman/go-sdk-local-core-tests.postman_collection.json`
 
 ## Core version notes
 
 | Issue | Core version | Why |
 |-------|--------------|-----|
+| #40 recover queue | 0.14.x+ | Not 0.15-only |
 | #73 search identities | 0.14.x+ | Not 0.15-only |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |
@@ -31,4 +41,4 @@ If `BLNK_API_KEY` is unset, integration tests skip.
 
 ## Postman
 
-Manual request seeds live in `manual/postman/`. Use those after integration tests pass.
+See `postman/README.md`. Use the collection runner after integration tests pass.

--- a/integration/issue40_test.go
+++ b/integration/issue40_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+// Integration tests for issue #40 — Transaction.RecoverQueue (POST /transactions/recover).
+// Requires Blnk Core running at http://localhost:5001 (docker compose up in blnk/).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue40
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue40_RecoverQueue_Default(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	result, resp, err := client.Transaction.RecoverQueue(blnkgo.RecoverQueueRequest{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, result.Recovered, 0)
+	require.NotEmpty(t, result.Threshold)
+}
+
+func TestIssue40_RecoverQueue_WithThreshold(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	result, resp, err := client.Transaction.RecoverQueue(blnkgo.RecoverQueueRequest{
+		Threshold: "24h",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, result.Recovered, 0)
+	require.Equal(t, "24h0m0s", result.Threshold)
+}
+
+func TestIssue40_RecoverQueue_InvalidThreshold(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Transaction.RecoverQueue(blnkgo.RecoverQueueRequest{
+		Threshold: "bogus",
+	})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "threshold must be a valid duration string")
+}

--- a/postman/README.md
+++ b/postman/README.md
@@ -18,6 +18,7 @@ Import these two files into Postman (one-time):
 |--------|---------------|--------------|
 | **Issue #73 — Search identities** | `POST /search/identities` | 0.14.5+ |
 | **Issue #36 — Transaction GetLineage** | `GET /transactions/{id}/lineage` | 0.14.5+ |
+| **Issue #40 — RecoverQueue** | `POST /transactions/recover` | 0.14.5+ |
 
 ## CLI (same tests, no Postman UI)
 

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Blnk Go SDK — Local Core Tests",
-    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests.",
+    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -35,6 +35,79 @@
     }
   ],
   "item": [
+    {
+      "name": "Issue #40 — RecoverQueue",
+      "item": [
+        {
+          "name": "1. Recover queue (default threshold)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('recovered and threshold returned', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.recovered).to.be.a('number');",
+                  "    pm.expect(json.recovered).to.be.at.least(0);",
+                  "    pm.expect(json.threshold).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
+            ],
+            "url": "{{blnk_base_url}}/transactions/recover",
+            "description": "Go SDK: Transaction.RecoverQueue({})"
+          }
+        },
+        {
+          "name": "2. Recover queue (threshold=24h)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('threshold echo matches Core', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.recovered).to.be.a('number');",
+                  "    pm.expect(json.threshold).to.eql('24h0m0s');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
+            ],
+            "url": {
+              "raw": "{{blnk_base_url}}/transactions/recover?threshold=24h",
+              "host": ["{{blnk_base_url}}"],
+              "path": ["transactions", "recover"],
+              "query": [
+                { "key": "threshold", "value": "24h" }
+              ]
+            },
+            "description": "Go SDK: Transaction.RecoverQueue({ Threshold: \"24h\" })"
+          }
+        }
+      ]
+    },
     {
       "name": "Issue #73 — Search identities",
       "item": [

--- a/transaction_recover.go
+++ b/transaction_recover.go
@@ -1,0 +1,44 @@
+package blnkgo
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// RecoverQueueRequest holds optional query parameters for POST /transactions/recover.
+// Threshold is a Go duration string (e.g. "5m", "1h"). Zero value omits the query
+// param and uses the Core default (2 minutes).
+type RecoverQueueRequest struct {
+	Threshold string `json:"-"`
+}
+
+// RecoverQueueResponse is returned after manually recovering stuck queued transactions.
+type RecoverQueueResponse struct {
+	Recovered int    `json:"recovered"`
+	Threshold string `json:"threshold"`
+}
+
+func (s *TransactionService) RecoverQueue(body RecoverQueueRequest) (*RecoverQueueResponse, *http.Response, error) {
+	if err := ValidateRecoverQueue(body); err != nil {
+		return nil, nil, err
+	}
+
+	endpoint := "transactions/recover"
+	if body.Threshold != "" {
+		endpoint = fmt.Sprintf("transactions/recover?threshold=%s", url.QueryEscape(body.Threshold))
+	}
+
+	req, err := s.client.NewRequest(endpoint, http.MethodPost, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response := new(RecoverQueueResponse)
+	resp, err := s.client.CallWithRetry(req, response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response, resp, nil
+}

--- a/transaction_recover_test.go
+++ b/transaction_recover_test.go
@@ -1,0 +1,113 @@
+package blnkgo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestTransactionService_RecoverQueue_Success(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	expectedResponse := &blnkgo.RecoverQueueResponse{
+		Recovered: 2,
+		Threshold: "2m0s",
+	}
+
+	mockClient.On("NewRequest", "transactions/recover", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		response := args.Get(1).(*blnkgo.RecoverQueueResponse)
+		*response = *expectedResponse
+	})
+
+	result, resp, err := svc.RecoverQueue(blnkgo.RecoverQueueRequest{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, result)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_RecoverQueue_WithThreshold(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	expectedResponse := &blnkgo.RecoverQueueResponse{
+		Recovered: 0,
+		Threshold: "24h0m0s",
+	}
+
+	mockClient.On("NewRequest", "transactions/recover?threshold=5m", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		response := args.Get(1).(*blnkgo.RecoverQueueResponse)
+		*response = *expectedResponse
+	})
+
+	result, resp, err := svc.RecoverQueue(blnkgo.RecoverQueueRequest{Threshold: "5m"})
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, result)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertCalled(t, "NewRequest", "transactions/recover?threshold=5m", http.MethodPost, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_RecoverQueue_InvalidThreshold(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	result, resp, err := svc.RecoverQueue(blnkgo.RecoverQueueRequest{Threshold: "bogus"})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "threshold must be a valid duration string")
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+}
+
+func TestTransactionService_RecoverQueue_NewRequestError(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	mockClient.On("NewRequest", "transactions/recover", http.MethodPost, nil).Return((*http.Request)(nil), assert.AnError)
+
+	result, resp, err := svc.RecoverQueue(blnkgo.RecoverQueueRequest{})
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_RecoverQueue_ServerError(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	mockClient.On("NewRequest", "transactions/recover", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return((*http.Response)(nil), assert.AnError)
+
+	result, resp, err := svc.RecoverQueue(blnkgo.RecoverQueueRequest{})
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestRecoverQueueResponse_UnmarshalJSON(t *testing.T) {
+	payload := []byte(`{"recovered":3,"threshold":"5m0s"}`)
+
+	var response blnkgo.RecoverQueueResponse
+	err := json.Unmarshal(payload, &response)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, response.Recovered)
+	assert.Equal(t, "5m0s", response.Threshold)
+}

--- a/validate_transactions.go
+++ b/validate_transactions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 )
 
 func ValidateCreateTransacation(t CreateTransactionRequest) error {
@@ -98,6 +99,16 @@ func ValidateCreateBulkTransaction(b CreateBulkTransactionRequest) error {
 		refs[tx.Reference] = struct{}{}
 	}
 
+	return nil
+}
+
+func ValidateRecoverQueue(r RecoverQueueRequest) error {
+	if r.Threshold == "" {
+		return nil
+	}
+	if _, err := time.ParseDuration(r.Threshold); err != nil {
+		return fmt.Errorf("threshold must be a valid duration string (e.g. 5m, 1h)")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Add `Transaction.RecoverQueue` calling `POST /transactions/recover`
- Types: `RecoverQueueRequest` (optional `threshold` query) and `RecoverQueueResponse` (`recovered`, `threshold`)
- Client-side threshold validation via `time.ParseDuration`
- Unit tests, integration tests, Postman folder, and README workflow steps

Closes #40

## Test plan

### 1. Unit tests
```bash
go test ./... -run RecoverQueue
```

### 2. Integration (Core 0.14.5)
```bash
cd ../blnk && docker compose up -d
export BLNK_API_KEY=blnk-local-dev-secret-change-me
go test -tags=integration -v ./integration/... -run Issue40
```

### 3. Postman
Import `postman/go-sdk-local-core-tests.postman_collection.json` + environment, then run folder **Issue #40 — RecoverQueue**.

Or via CLI:
```bash
npx newman run postman/go-sdk-local-core-tests.postman_collection.json \
  -e postman/go-sdk-local-core.postman_environment.json \
  --folder "Issue #40 — RecoverQueue"
```

- [x] `go test ./...`
- [x] `go test -tags=integration ./integration/... -run Issue40`
- [x] Newman Issue #40 folder — 4/4 assertions pass