### PR TITLE
Transaction.Refund: optional skip_queue body (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,8 +359,8 @@ fmt.Printf("Recovered %d transactions (threshold %s)\n", result.Recovered, resul
 Refund by transaction ID. Omit the body to queue the refund (Core default), or pass `skip_queue: true` for synchronous processing:
 
 ```go
-// Queued refund (default)
-refund, resp, err := client.Transaction.Refund(originalTxnID, nil)
+// Queued refund (default) — existing callers keep working without a second argument
+refund, resp, err := client.Transaction.Refund(originalTxnID)
 
 // Synchronous refund
 refund, resp, err := client.Transaction.Refund(originalTxnID, &blnkgo.RefundTransactionRequest{

--- a/README.md
+++ b/README.md
@@ -354,6 +354,20 @@ if err != nil {
 fmt.Printf("Recovered %d transactions (threshold %s)\n", result.Recovered, result.Threshold)
 ```
 
+### Refunding a Transaction
+
+Refund by transaction ID. Omit the body to queue the refund (Core default), or pass `skip_queue: true` for synchronous processing:
+
+```go
+// Queued refund (default)
+refund, resp, err := client.Transaction.Refund(originalTxnID, nil)
+
+// Synchronous refund
+refund, resp, err := client.Transaction.Refund(originalTxnID, &blnkgo.RefundTransactionRequest{
+    SkipQueue: true,
+})
+```
+
 ### Getting a Transaction by Reference
 
 Look up a transaction using its unique reference string:

--- a/integration/README.md
+++ b/integration/README.md
@@ -12,6 +12,7 @@ export BLNK_API_KEY=your_master_or_api_key
 
 ```bash
 # one issue
+go test -tags=integration -v ./integration/... -run Issue70
 go test -tags=integration -v ./integration/... -run Issue40
 go test -tags=integration -v ./integration/... -run Issue73
 go test -tags=integration -v ./integration/... -run Issue36
@@ -33,6 +34,7 @@ go test -tags=integration -v ./integration/...
 | Issue | Core version | Why |
 |-------|--------------|-----|
 | #40 recover queue | 0.14.x+ | Not 0.15-only |
+| #70 refund skip_queue | 0.14.x+ | Optional body on POST /refund-transaction/{id} |
 | #73 search identities | 0.14.x+ | Not 0.15-only |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |

--- a/integration/issue70_test.go
+++ b/integration/issue70_test.go
@@ -65,6 +65,37 @@ func TestIssue70_Refund_SkipQueueSynchronous(t *testing.T) {
 	require.Equal(t, originalTxnID, refund.ParentTransactionID)
 }
 
+func TestIssue70_Refund_ReversesSourceAndDestination(t *testing.T) {
+	client := newIntegrationClient(t)
+	ref := fmt.Sprintf("issue70-reversal-%d", time.Now().UnixNano())
+
+	original, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      500,
+			Reference:   ref,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Destination: "@Recipient",
+			Description: "Refund reversal integration tx",
+			SkipQueue:   true,
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	refund, resp, err := client.Transaction.Refund(original.TransactionID, &blnkgo.RefundTransactionRequest{
+		SkipQueue: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.Equal(t, original.Amount, refund.Amount)
+	require.Equal(t, original.Destination, refund.Source)
+	require.Equal(t, original.Source, refund.Destination)
+	require.Equal(t, original.TransactionID, refund.ParentTransactionID)
+}
+
 func TestIssue70_Refund_DuplicateRefundRejected(t *testing.T) {
 	client := newIntegrationClient(t)
 	originalTxnID := createAppliedTransaction(t, client, "issue70-dup")

--- a/integration/issue70_test.go
+++ b/integration/issue70_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+// Integration tests for issue #70 — Transaction.Refund optional skip_queue body.
+// Requires Blnk Core running at http://localhost:5001 (docker compose up in blnk/).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue70
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func createAppliedTransaction(t *testing.T, client *blnkgo.Client, refPrefix string) string {
+	t.Helper()
+	ref := fmt.Sprintf("%s-%d", refPrefix, time.Now().UnixNano())
+
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      500,
+			Reference:   ref,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Destination: "@Recipient",
+			Description: "Refund integration source tx",
+			SkipQueue:   true,
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+	require.Equal(t, blnkgo.PryTransactionStatus("APPLIED"), txn.Status)
+	return txn.TransactionID
+}
+
+func TestIssue70_Refund_QueuedDefault(t *testing.T) {
+	client := newIntegrationClient(t)
+	originalTxnID := createAppliedTransaction(t, client, "issue70-queued")
+
+	refund, resp, err := client.Transaction.Refund(originalTxnID, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, refund.TransactionID)
+}
+
+func TestIssue70_Refund_SkipQueueSynchronous(t *testing.T) {
+	client := newIntegrationClient(t)
+	originalTxnID := createAppliedTransaction(t, client, "issue70-sync")
+
+	refund, resp, err := client.Transaction.Refund(originalTxnID, &blnkgo.RefundTransactionRequest{
+		SkipQueue: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, refund.TransactionID)
+	require.Equal(t, blnkgo.PryTransactionStatus("APPLIED"), refund.Status)
+}

--- a/integration/issue70_test.go
+++ b/integration/issue70_test.go
@@ -44,10 +44,11 @@ func TestIssue70_Refund_QueuedDefault(t *testing.T) {
 	client := newIntegrationClient(t)
 	originalTxnID := createAppliedTransaction(t, client, "issue70-queued")
 
-	refund, resp, err := client.Transaction.Refund(originalTxnID, nil)
+	refund, resp, err := client.Transaction.Refund(originalTxnID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 	require.NotEmpty(t, refund.TransactionID)
+	require.Equal(t, originalTxnID, refund.ParentTransactionID)
 }
 
 func TestIssue70_Refund_SkipQueueSynchronous(t *testing.T) {
@@ -61,4 +62,23 @@ func TestIssue70_Refund_SkipQueueSynchronous(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 	require.NotEmpty(t, refund.TransactionID)
 	require.Equal(t, blnkgo.PryTransactionStatus("APPLIED"), refund.Status)
+	require.Equal(t, originalTxnID, refund.ParentTransactionID)
+}
+
+func TestIssue70_Refund_DuplicateRefundRejected(t *testing.T) {
+	client := newIntegrationClient(t)
+	originalTxnID := createAppliedTransaction(t, client, "issue70-dup")
+
+	_, resp, err := client.Transaction.Refund(originalTxnID, &blnkgo.RefundTransactionRequest{
+		SkipQueue: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	_, dupResp, dupErr := client.Transaction.Refund(originalTxnID, &blnkgo.RefundTransactionRequest{
+		SkipQueue: true,
+	})
+	require.Error(t, dupErr)
+	require.NotNil(t, dupResp)
+	require.NotEqual(t, http.StatusCreated, dupResp.StatusCode)
 }

--- a/postman/README.md
+++ b/postman/README.md
@@ -19,6 +19,7 @@ Import these two files into Postman (one-time):
 | **Issue #73 — Search identities** | `POST /search/identities` | 0.14.5+ |
 | **Issue #36 — Transaction GetLineage** | `GET /transactions/{id}/lineage` | 0.14.5+ |
 | **Issue #40 — RecoverQueue** | `POST /transactions/recover` | 0.14.5+ |
+| **Issue #70 — Refund skip_queue** | `POST /refund-transaction/{id}` | 0.14.5+ |
 
 ## CLI (same tests, no Postman UI)
 

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -178,7 +178,7 @@
               { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
             ],
             "url": "{{blnk_base_url}}/refund-transaction/{{refund_source_txn_id}}",
-            "description": "Go SDK: Transaction.Refund(id, nil)"
+            "description": "Go SDK: Transaction.Refund(id)"
           }
         },
         {

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Blnk Go SDK — Local Core Tests",
-    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
+    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -104,6 +104,155 @@
               ]
             },
             "description": "Go SDK: Transaction.RecoverQueue({ Threshold: \"24h\" })"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Issue #70 — Refund skip_queue",
+      "item": [
+        {
+          "name": "1. Create applied transaction (seed)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('refund_ref', `issue70-${Date.now()}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.expect(json.status).to.eql('APPLIED');",
+                  "pm.collectionVariables.set('refund_source_txn_id', json.transaction_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 500,\n  \"reference\": \"{{refund_ref}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"@FundingPool\",\n  \"destination\": \"@Recipient\",\n  \"skip_queue\": true,\n  \"allow_overdraft\": true,\n  \"description\": \"Go SDK refund test source\"\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions"
+          }
+        },
+        {
+          "name": "2. Refund (queued default, no body)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.test('refund transaction_id returned', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.transaction_id).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
+            ],
+            "url": "{{blnk_base_url}}/refund-transaction/{{refund_source_txn_id}}",
+            "description": "Go SDK: Transaction.Refund(id, nil)"
+          }
+        },
+        {
+          "name": "3. Create second applied transaction",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('refund_sync_ref', `issue70-sync-${Date.now()}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('refund_sync_source_txn_id', json.transaction_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 500,\n  \"reference\": \"{{refund_sync_ref}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"@FundingPool\",\n  \"destination\": \"@Recipient\",\n  \"skip_queue\": true,\n  \"allow_overdraft\": true,\n  \"description\": \"Go SDK sync refund test source\"\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions"
+          }
+        },
+        {
+          "name": "4. Refund (skip_queue synchronous)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.test('refund applied synchronously', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.status).to.eql('APPLIED');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"skip_queue\": true\n}"
+            },
+            "url": "{{blnk_base_url}}/refund-transaction/{{refund_sync_source_txn_id}}",
+            "description": "Go SDK: Transaction.Refund(id, &RefundTransactionRequest{SkipQueue: true})"
           }
         }
       ]

--- a/transaction.go
+++ b/transaction.go
@@ -46,8 +46,9 @@ type CreateTransactionRequest struct {
 
 type Transaction struct {
 	ParentTransaction
-	CreatedAt     time.Time `json:"created_at"`
-	TransactionID string    `json:"transaction_id"`
+	CreatedAt           time.Time `json:"created_at"`
+	TransactionID       string    `json:"transaction_id"`
+	ParentTransactionID string    `json:"parent_transaction,omitempty"`
 }
 
 type UpdateStatus struct {
@@ -229,21 +230,20 @@ func (s *TransactionService) Update(transactionID string, body UpdateStatus) (*T
 	return transaction, resp, nil
 }
 
-func (s *TransactionService) Refund(transactionID string, body *RefundTransactionRequest) (*Transaction, *http.Response, error) {
+func (s *TransactionService) Refund(transactionID string, body ...*RefundTransactionRequest) (*Transaction, *http.Response, error) {
 	if transactionID == "" {
 		return nil, nil, fmt.Errorf("transactionID is required")
 	}
-	if body != nil {
-		if err := ValidateRefundTransaction(*body); err != nil {
+
+	var reqBody interface{}
+	if len(body) > 0 && body[0] != nil {
+		if err := ValidateRefundTransaction(*body[0]); err != nil {
 			return nil, nil, err
 		}
+		reqBody = body[0]
 	}
 
 	u := fmt.Sprintf("refund-transaction/%s", transactionID)
-	var reqBody interface{}
-	if body != nil {
-		reqBody = body
-	}
 	req, err := s.client.NewRequest(u, http.MethodPost, reqBody)
 	if err != nil {
 		return nil, nil, err

--- a/transaction.go
+++ b/transaction.go
@@ -71,6 +71,12 @@ type CreateBulkTransactionResponse struct {
 	Message          string `json:"message,omitempty"`
 }
 
+// RefundTransactionRequest is the optional body for POST /refund-transaction/{id}.
+// Omit the body (pass nil) to queue the refund using Core defaults.
+type RefundTransactionRequest struct {
+	SkipQueue bool `json:"skip_queue,omitempty"`
+}
+
 // MaxBulkInflightItems caps the number of transactions accepted in a single
 // bulk commit or bulk void call.
 const MaxBulkInflightItems = 100
@@ -223,9 +229,22 @@ func (s *TransactionService) Update(transactionID string, body UpdateStatus) (*T
 	return transaction, resp, nil
 }
 
-func (s *TransactionService) Refund(transactionID string) (*Transaction, *http.Response, error) {
+func (s *TransactionService) Refund(transactionID string, body *RefundTransactionRequest) (*Transaction, *http.Response, error) {
+	if transactionID == "" {
+		return nil, nil, fmt.Errorf("transactionID is required")
+	}
+	if body != nil {
+		if err := ValidateRefundTransaction(*body); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	u := fmt.Sprintf("refund-transaction/%s", transactionID)
-	req, err := s.client.NewRequest(u, http.MethodPost, nil)
+	var reqBody interface{}
+	if body != nil {
+		reqBody = body
+	}
+	req, err := s.client.NewRequest(u, http.MethodPost, reqBody)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -234,6 +234,9 @@ func (s *TransactionService) Refund(transactionID string, body ...*RefundTransac
 	if transactionID == "" {
 		return nil, nil, fmt.Errorf("transactionID is required")
 	}
+	if len(body) > 1 {
+		return nil, nil, fmt.Errorf("Refund accepts at most one optional request body")
+	}
 
 	var reqBody interface{}
 	if len(body) > 0 && body[0] != nil {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -402,7 +402,7 @@ func TestRefundTransaction(t *testing.T) {
 		}
 	})
 
-	transaction, resp, err := svc.Refund("txn-123", nil)
+	transaction, resp, err := svc.Refund("txn-123")
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
@@ -450,7 +450,7 @@ func TestRefundTransaction_WithSkipQueue(t *testing.T) {
 func TestRefundTransaction_EmptyTransactionID(t *testing.T) {
 	mockClient, svc := setupTransactionService()
 
-	result, resp, err := svc.Refund("", nil)
+	result, resp, err := svc.Refund("")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "transactionID is required")
@@ -464,7 +464,7 @@ func TestRefundTransaction_FailedRequest(t *testing.T) {
 
 	mockClient.On("NewRequest", "refund-transaction/txn-123", http.MethodPost, nil).Return(nil, errors.New("failed to create request"))
 
-	transaction, resp, err := svc.Refund("txn-123", nil)
+	transaction, resp, err := svc.Refund("txn-123")
 
 	assert.Error(t, err)
 	assert.Nil(t, transaction)
@@ -481,7 +481,7 @@ func TestRefundTransaction_ClientError(t *testing.T) {
 	mockClient.On("NewRequest", "refund-transaction/txn-123", http.MethodPost, nil).Return(&http.Request{}, nil)
 	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusBadRequest}, errors.New("client error"))
 
-	transaction, resp, err := svc.Refund("txn-123", nil)
+	transaction, resp, err := svc.Refund("txn-123")
 
 	assert.Error(t, err)
 	assert.Nil(t, transaction)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -402,7 +402,7 @@ func TestRefundTransaction(t *testing.T) {
 		}
 	})
 
-	transaction, resp, err := svc.Refund("txn-123")
+	transaction, resp, err := svc.Refund("txn-123", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
@@ -412,12 +412,59 @@ func TestRefundTransaction(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestRefundTransaction_WithSkipQueue(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	refundBody := &blnkgo.RefundTransactionRequest{SkipQueue: true}
+
+	mockClient.On(
+		"NewRequest",
+		"refund-transaction/txn-456",
+		http.MethodPost,
+		mock.MatchedBy(func(body interface{}) bool {
+			req, ok := body.(*blnkgo.RefundTransactionRequest)
+			return ok && req.SkipQueue
+		}),
+	).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusCreated,
+	}, nil).Run(func(args mock.Arguments) {
+		transaction := args.Get(1).(*blnkgo.Transaction)
+		*transaction = blnkgo.Transaction{
+			ParentTransaction: blnkgo.ParentTransaction{
+				Status: blnkgo.PryTransactionStatus("APPLIED"),
+			},
+			TransactionID: "txn-refund-sync",
+		}
+	})
+
+	result, resp, err := svc.Refund("txn-456", refundBody)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, "txn-refund-sync", result.TransactionID)
+	assert.Equal(t, blnkgo.PryTransactionStatus("APPLIED"), result.Status)
+	mockClient.AssertExpectations(t)
+}
+
+func TestRefundTransaction_EmptyTransactionID(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	result, resp, err := svc.Refund("", nil)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "transactionID is required")
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+}
+
 func TestRefundTransaction_FailedRequest(t *testing.T) {
 	mockClient, svc := setupTransactionService()
 
 	mockClient.On("NewRequest", "refund-transaction/txn-123", http.MethodPost, nil).Return(nil, errors.New("failed to create request"))
 
-	transaction, resp, err := svc.Refund("txn-123")
+	transaction, resp, err := svc.Refund("txn-123", nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, transaction)
@@ -434,7 +481,7 @@ func TestRefundTransaction_ClientError(t *testing.T) {
 	mockClient.On("NewRequest", "refund-transaction/txn-123", http.MethodPost, nil).Return(&http.Request{}, nil)
 	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusBadRequest}, errors.New("client error"))
 
-	transaction, resp, err := svc.Refund("txn-123")
+	transaction, resp, err := svc.Refund("txn-123", nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, transaction)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -412,6 +412,74 @@ func TestRefundTransaction(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestRefundTransaction_BackwardCompatibleNoBody(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	mockClient.On("NewRequest", "refund-transaction/txn-compat", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusCreated,
+	}, nil)
+
+	_, resp, err := svc.Refund("txn-compat")
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	mockClient.AssertCalled(t, "NewRequest", "refund-transaction/txn-compat", http.MethodPost, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestRefundTransaction_ExplicitNilBody(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	mockClient.On("NewRequest", "refund-transaction/txn-nil-body", http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusCreated,
+	}, nil)
+
+	_, _, err := svc.Refund("txn-nil-body", nil)
+
+	assert.NoError(t, err)
+	mockClient.AssertCalled(t, "NewRequest", "refund-transaction/txn-nil-body", http.MethodPost, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestRefundTransaction_TooManyBodies(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	result, resp, err := svc.Refund("txn-123",
+		&blnkgo.RefundTransactionRequest{SkipQueue: true},
+		&blnkgo.RefundTransactionRequest{SkipQueue: true},
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at most one optional request body")
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+}
+
+func TestTransaction_ParentTransaction_UnmarshalJSON(t *testing.T) {
+	payload := []byte(`{
+		"transaction_id": "txn_refund_1",
+		"parent_transaction": "txn_original_1",
+		"amount": 500,
+		"source": "@Recipient",
+		"destination": "@FundingPool",
+		"status": "APPLIED"
+	}`)
+
+	var txn blnkgo.Transaction
+	err := json.Unmarshal(payload, &txn)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "txn_refund_1", txn.TransactionID)
+	assert.Equal(t, "txn_original_1", txn.ParentTransactionID)
+	assert.Equal(t, float64(500), txn.Amount)
+	assert.Equal(t, "@Recipient", txn.Source)
+	assert.Equal(t, "@FundingPool", txn.Destination)
+	assert.Equal(t, blnkgo.PryTransactionStatus("APPLIED"), txn.Status)
+}
+
 func TestRefundTransaction_WithSkipQueue(t *testing.T) {
 	mockClient, svc := setupTransactionService()
 	refundBody := &blnkgo.RefundTransactionRequest{SkipQueue: true}

--- a/validate_transactions.go
+++ b/validate_transactions.go
@@ -112,6 +112,12 @@ func ValidateRecoverQueue(r RecoverQueueRequest) error {
 	return nil
 }
 
+func ValidateRefundTransaction(r RefundTransactionRequest) error {
+	// RefundTransactionRequest only exposes skip_queue; no extra field validation needed
+	// beyond JSON types. Kept for parity with other transaction validators.
+	return nil
+}
+
 func validateSources(sources []Source, amount float64, sb *strings.Builder) error {
 	//total amount of sources  must be equal to the amount
 	total := 0.0


### PR DESCRIPTION
## Summary
- Add `RefundTransactionRequest` with optional `skip_queue`
- Update `Transaction.Refund(transactionID, body *RefundTransactionRequest)` — pass `nil` for bodiless queued refund (backward-compatible call shape)
- Unit tests for nil body, `skip_queue: true`, and empty transaction ID
- Integration tests: queued default vs synchronous refund
- Postman folder **Issue #70 — Refund skip_queue**

Closes #70

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration ./integration/... -run Issue70`
- [x] Newman folder Issue #70 — 6/6 assertions pass

### Run locally
```bash
export BLNK_API_KEY=blnk-local-dev-secret-change-me
go test ./... -run Refund
go test -tags=integration -v ./integration/... -run Issue70
npx newman run postman/go-sdk-local-core-tests.postman_collection.json \
  -e postman/go-sdk-local-core.postman_environment.json \
  --folder "Issue #70 — Refund skip_queue"
```