### PR TITLE
Add precise_distribution on split legs (#71)

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -13,6 +13,7 @@ export BLNK_API_KEY=your_master_or_api_key
 ```bash
 # one issue
 go test -tags=integration -v ./integration/... -run Issue70
+go test -tags=integration -v ./integration/... -run Issue71
 go test -tags=integration -v ./integration/... -run Issue40
 go test -tags=integration -v ./integration/... -run Issue73
 go test -tags=integration -v ./integration/... -run Issue36
@@ -35,6 +36,7 @@ go test -tags=integration -v ./integration/...
 |-------|--------------|-----|
 | #40 recover queue | 0.14.x+ | Not 0.15-only |
 | #70 refund skip_queue | 0.14.x+ | Optional body on POST /refund-transaction/{id} |
+| #71 precise_distribution | 0.14.x+ | Split legs with precise_distribution on POST /transactions |
 | #73 search identities | 0.14.x+ | Not 0.15-only |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |

--- a/integration/issue71_test.go
+++ b/integration/issue71_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+
+// Integration tests for issue #71 — precise_distribution on split legs (POST /transactions).
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue71
+package integration
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue71_PreciseDistributionLegs(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "Issue71 Precise " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	merchant, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	fee, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      10000,
+			Reference:   "issue71-precise-" + suffix,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Description: "Issue 71 precise_distribution legs",
+			SkipQueue:   true,
+			Destinations: []blnkgo.Source{
+				{Identifier: merchant.BalanceID, PreciseDistribution: "9733"},
+				{Identifier: fee.BalanceID, PreciseDistribution: "267"},
+			},
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+}
+
+func TestIssue71_MixedDecimalPreciseDistributionAndLeft(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "Issue71 Mixed " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	balances := make([]string, 3)
+	for i := range balances {
+		bal, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+			LedgerID: ledger.LedgerID,
+			Currency: "USD",
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		balances[i] = bal.BalanceID
+	}
+
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      30000,
+			Reference:   "issue71-mix-" + suffix,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Description: "Issue 71 mixed split legs",
+			SkipQueue:   true,
+			Destinations: []blnkgo.Source{
+				{Identifier: balances[0], Distribution: "33.33%"},
+				{Identifier: balances[1], PreciseDistribution: "5000"},
+				{Identifier: balances[2], Distribution: "left"},
+			},
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+}
+
+func TestIssue71_PreciseAmountWithPreciseDistributionLegs(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "Issue71 PreciseAmt " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	dest, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			PreciseAmount: big.NewInt(10000),
+			Reference:     "issue71-pamt-" + suffix,
+			Precision:     100,
+			Currency:      "USD",
+			Source:        "@FundingPool",
+			Description:   "Issue 71 precise_amount split",
+			SkipQueue:     true,
+			Destinations: []blnkgo.Source{
+				{Identifier: dest.BalanceID, PreciseDistribution: "9733"},
+				{Identifier: "@Recipient", PreciseDistribution: "267"},
+			},
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+}

--- a/integration/issue71_test.go
+++ b/integration/issue71_test.go
@@ -118,6 +118,49 @@ func TestIssue71_MixedDecimalPreciseDistributionAndLeft(t *testing.T) {
 	require.NotEmpty(t, txn.TransactionID)
 }
 
+func TestIssue71_PreciseAmountWithClassicDistribution_BackwardCompat(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "Issue71 Compat " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	destA, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	destB, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			PreciseAmount: big.NewInt(50000),
+			Reference:     "issue71-compat-" + suffix,
+			Precision:     100,
+			Currency:      "USD",
+			Source:        "@FundingPool",
+			Description:   "Issue 71 precise_amount classic distribution compat",
+			SkipQueue:     true,
+			Destinations: []blnkgo.Source{
+				{Identifier: destA.BalanceID, Distribution: "50%"},
+				{Identifier: destB.BalanceID, Distribution: "left"},
+			},
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+}
+
 func TestIssue71_PreciseAmountWithPreciseDistributionLegs(t *testing.T) {
 	client := newIntegrationClient(t)
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())

--- a/integration/issue71_test.go
+++ b/integration/issue71_test.go
@@ -44,13 +44,13 @@ func TestIssue71_PreciseDistributionLegs(t *testing.T) {
 
 	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
 		ParentTransaction: blnkgo.ParentTransaction{
-			Amount:      10000,
-			Reference:   "issue71-precise-" + suffix,
-			Precision:   100,
-			Currency:    "USD",
-			Source:      "@FundingPool",
-			Description: "Issue 71 precise_distribution legs",
-			SkipQueue:   true,
+			PreciseAmount: big.NewInt(10000),
+			Reference:     "issue71-precise-" + suffix,
+			Precision:     100,
+			Currency:      "USD",
+			Source:        "@FundingPool",
+			Description:   "Issue 71 precise_distribution legs",
+			SkipQueue:     true,
 			Destinations: []blnkgo.Source{
 				{Identifier: merchant.BalanceID, PreciseDistribution: "9733"},
 				{Identifier: fee.BalanceID, PreciseDistribution: "267"},
@@ -61,6 +61,20 @@ func TestIssue71_PreciseDistributionLegs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 	require.NotEmpty(t, txn.TransactionID)
+
+	merchantAfter, resp, err := client.LedgerBalance.Get(merchant.BalanceID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, merchantAfter.CreditBalance)
+	require.Equal(t, 0, big.NewInt(9733).Cmp(merchantAfter.CreditBalance),
+		"merchant credit should equal precise_distribution leg amount")
+
+	feeAfter, resp, err := client.LedgerBalance.Get(fee.BalanceID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, feeAfter.CreditBalance)
+	require.Equal(t, 0, big.NewInt(267).Cmp(feeAfter.CreditBalance),
+		"fee credit should equal precise_distribution leg amount")
 }
 
 func TestIssue71_MixedDecimalPreciseDistributionAndLeft(t *testing.T) {

--- a/postman/README.md
+++ b/postman/README.md
@@ -20,6 +20,7 @@ Import these two files into Postman (one-time):
 | **Issue #36 — Transaction GetLineage** | `GET /transactions/{id}/lineage` | 0.14.5+ |
 | **Issue #40 — RecoverQueue** | `POST /transactions/recover` | 0.14.5+ |
 | **Issue #70 — Refund skip_queue** | `POST /refund-transaction/{id}` | 0.14.5+ |
+| **Issue #71 — precise_distribution** | `POST /transactions` split legs | 0.14.5+ |
 
 ## CLI (same tests, no Postman UI)
 

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Blnk Go SDK — Local Core Tests",
-    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
+    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #71 — precise_distribution split legs\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -31,6 +31,18 @@
     },
     {
       "key": "transaction_id",
+      "value": ""
+    },
+    {
+      "key": "issue71_merchant_id",
+      "value": ""
+    },
+    {
+      "key": "issue71_fee_id",
+      "value": ""
+    },
+    {
+      "key": "issue71_balance_c",
       "value": ""
     }
   ],
@@ -253,6 +265,221 @@
             },
             "url": "{{blnk_base_url}}/refund-transaction/{{refund_sync_source_txn_id}}",
             "description": "Go SDK: Transaction.Refund(id, &RefundTransactionRequest{SkipQueue: true})"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Issue #71 — precise_distribution split legs",
+      "item": [
+        {
+          "name": "1. Create ledger",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('ledger_id', json.ledger_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Go SDK Issue71 Precise Distribution\"\n}"
+            },
+            "url": "{{blnk_base_url}}/ledgers"
+          }
+        },
+        {
+          "name": "2. Create merchant balance",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('issue71_merchant_id', json.balance_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ledger_id\": \"{{ledger_id}}\",\n  \"currency\": \"USD\"\n}"
+            },
+            "url": "{{blnk_base_url}}/balances"
+          }
+        },
+        {
+          "name": "3. Create fee balance",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('issue71_fee_id', json.balance_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ledger_id\": \"{{ledger_id}}\",\n  \"currency\": \"USD\"\n}"
+            },
+            "url": "{{blnk_base_url}}/balances"
+          }
+        },
+        {
+          "name": "4. Create split txn (precise_distribution legs)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('issue71_ref', `issue71-precise-${Date.now()}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.test('transaction_id returned', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.transaction_id).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 10000,\n  \"reference\": \"{{issue71_ref}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"@FundingPool\",\n  \"skip_queue\": true,\n  \"allow_overdraft\": true,\n  \"description\": \"Issue 71 precise_distribution legs\",\n  \"destinations\": [\n    {\"identifier\": \"{{issue71_merchant_id}}\", \"precise_distribution\": \"9733\"},\n    {\"identifier\": \"{{issue71_fee_id}}\", \"precise_distribution\": \"267\"}\n  ]\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions",
+            "description": "Go SDK: Source.PreciseDistribution on split legs (9733 + 267 = 10000)"
+          }
+        },
+        {
+          "name": "5. Create balance C (mixed split)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('issue71_balance_c', json.balance_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ledger_id\": \"{{ledger_id}}\",\n  \"currency\": \"USD\"\n}"
+            },
+            "url": "{{blnk_base_url}}/balances"
+          }
+        },
+        {
+          "name": "6. Create split txn (mixed % + precise_distribution + left)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('issue71_mix_ref', `issue71-mix-${Date.now()}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.test('transaction_id returned', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.transaction_id).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 30000,\n  \"reference\": \"{{issue71_mix_ref}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"@FundingPool\",\n  \"skip_queue\": true,\n  \"allow_overdraft\": true,\n  \"description\": \"Issue 71 mixed split legs\",\n  \"destinations\": [\n    {\"identifier\": \"{{issue71_merchant_id}}\", \"distribution\": \"33.33%\"},\n    {\"identifier\": \"{{issue71_fee_id}}\", \"precise_distribution\": \"5000\"},\n    {\"identifier\": \"{{issue71_balance_c}}\", \"distribution\": \"left\"}\n  ]\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions",
+            "description": "Go SDK: mixed decimal %, precise_distribution, and left on split legs"
           }
         }
       ]

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -402,10 +402,66 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"amount\": 10000,\n  \"reference\": \"{{issue71_ref}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"@FundingPool\",\n  \"skip_queue\": true,\n  \"allow_overdraft\": true,\n  \"description\": \"Issue 71 precise_distribution legs\",\n  \"destinations\": [\n    {\"identifier\": \"{{issue71_merchant_id}}\", \"precise_distribution\": \"9733\"},\n    {\"identifier\": \"{{issue71_fee_id}}\", \"precise_distribution\": \"267\"}\n  ]\n}"
+              "raw": "{\n  \"precise_amount\": 10000,\n  \"reference\": \"{{issue71_ref}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"@FundingPool\",\n  \"skip_queue\": true,\n  \"allow_overdraft\": true,\n  \"description\": \"Issue 71 precise_distribution legs\",\n  \"destinations\": [\n    {\"identifier\": \"{{issue71_merchant_id}}\", \"precise_distribution\": \"9733\"},\n    {\"identifier\": \"{{issue71_fee_id}}\", \"precise_distribution\": \"267\"}\n  ]\n}"
             },
             "url": "{{blnk_base_url}}/transactions",
-            "description": "Go SDK: Source.PreciseDistribution on split legs (9733 + 267 = 10000)"
+            "description": "Go SDK: Source.PreciseDistribution with precise_amount (9733 + 267 = 10000 minor units)"
+          }
+        },
+        {
+          "name": "4b. Verify merchant credit (9733)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('merchant credit equals precise_distribution leg', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(String(json.credit_balance)).to.eql('9733');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
+            ],
+            "url": "{{blnk_base_url}}/balances/{{issue71_merchant_id}}"
+          }
+        },
+        {
+          "name": "4c. Verify fee credit (267)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('fee credit equals precise_distribution leg', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(String(json.credit_balance)).to.eql('267');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
+            ],
+            "url": "{{blnk_base_url}}/balances/{{issue71_fee_id}}"
           }
         },
         {

--- a/transaction.go
+++ b/transaction.go
@@ -11,9 +11,10 @@ import (
 type TransactionService service
 
 type Source struct {
-	Identifier   string       `json:"identifier"`
-	Distribution Distribution `json:"distribution"`
-	Narration    string       `json:"narration,omitempty"`
+	Identifier          string       `json:"identifier"`
+	Distribution        Distribution `json:"distribution,omitempty"`
+	PreciseDistribution string       `json:"precise_distribution,omitempty"`
+	Narration           string       `json:"narration,omitempty"`
 }
 
 type ParentTransaction struct {

--- a/validate_transactions.go
+++ b/validate_transactions.go
@@ -183,6 +183,9 @@ func resolveSplitLegTotal(t CreateTransactionRequest) (splitLegTotal, error) {
 
 	if usesPreciseIntegerArithmetic(t) {
 		if t.Amount != 0 {
+			if t.Amount != math.Trunc(t.Amount) {
+				return zero, errors.New("validation error: amount must be a whole number when split legs use precise_distribution")
+			}
 			return splitLegTotal{bigInt: big.NewInt(int64(t.Amount)), mode: "bigint"}, nil
 		}
 		if hasPreciseAmount {

--- a/validate_transactions.go
+++ b/validate_transactions.go
@@ -3,10 +3,13 @@ package blnkgo
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"strings"
 	"time"
 )
+
+const distributionSumEpsilon = 1e-9
 
 func ValidateCreateTransacation(t CreateTransactionRequest) error {
 	var sb strings.Builder
@@ -36,16 +39,14 @@ func ValidateCreateTransacation(t CreateTransactionRequest) error {
 		return errors.New(sb.String())
 	}
 
-	if len(t.Sources) > 0 && (t.PreciseAmount == nil || t.PreciseAmount.Cmp(big.NewInt(0)) == 0) {
-		err := validateSources(t.Sources, t.Amount, &sb)
-		if err != nil {
+	if len(t.Sources) > 0 {
+		if err := validateSplitLegs(t.Sources, t, "source"); err != nil {
 			return err
 		}
 	}
 
-	if len(t.Destinations) > 0 && (t.PreciseAmount == nil || t.PreciseAmount.Cmp(big.NewInt(0)) == 0) {
-		err := validateSources(t.Destinations, t.Amount, &sb)
-		if err != nil {
+	if len(t.Destinations) > 0 {
+		if err := validateSplitLegs(t.Destinations, t, "destination"); err != nil {
 			return err
 		}
 	}
@@ -118,68 +119,260 @@ func ValidateRefundTransaction(r RefundTransactionRequest) error {
 	return nil
 }
 
-func validateSources(sources []Source, amount float64, sb *strings.Builder) error {
-	//total amount of sources  must be equal to the amount
-	total := 0.0
+func hasPreciseDistribution(leg Source) bool {
+	return leg.PreciseDistribution != ""
+}
+
+func usesPreciseIntegerArithmetic(t CreateTransactionRequest) bool {
+	for _, leg := range t.Sources {
+		if hasPreciseDistribution(leg) {
+			return true
+		}
+	}
+	for _, leg := range t.Destinations {
+		if hasPreciseDistribution(leg) {
+			return true
+		}
+	}
+	if t.PreciseAmount != nil && t.Amount == 0 {
+		return true
+	}
+	return false
+}
+
+func parsePreciseInteger(raw string) (*big.Int, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || trimmed != raw {
+		return nil, false
+	}
+	n := new(big.Int)
+	if _, ok := n.SetString(trimmed, 10); !ok || n.Sign() < 0 {
+		return nil, false
+	}
+	return n, true
+}
+
+func legUsesDecimalDistribution(leg Source) bool {
+	if leg.Distribution == "" {
+		return false
+	}
+	if leg.Distribution.IsPercentage() {
+		pct := leg.Distribution.ToPercentage()
+		return pct != math.Trunc(pct)
+	}
+	if leg.Distribution.IsNumber() {
+		num := leg.Distribution.ToNumber()
+		return num != math.Trunc(num)
+	}
+	return false
+}
+
+type splitLegTotal struct {
+	bigInt *big.Int
+	float  float64
+	mode   string
+}
+
+func resolveSplitLegTotal(t CreateTransactionRequest) (splitLegTotal, error) {
+	var zero splitLegTotal
+	hasPreciseAmount := t.PreciseAmount != nil
+
+	if t.Amount == 0 && !hasPreciseAmount {
+		return zero, errors.New("validation error: amount or precise_amount is required for split legs")
+	}
+
+	if usesPreciseIntegerArithmetic(t) {
+		if t.Amount != 0 {
+			return splitLegTotal{bigInt: big.NewInt(int64(t.Amount)), mode: "bigint"}, nil
+		}
+		if hasPreciseAmount {
+			return splitLegTotal{bigInt: new(big.Int).Set(t.PreciseAmount), mode: "bigint"}, nil
+		}
+	}
+
+	if t.Amount != 0 {
+		return splitLegTotal{float: t.Amount, mode: "float"}, nil
+	}
+
+	if hasPreciseAmount {
+		if t.PreciseAmount.Sign() < 0 {
+			return zero, errors.New("validation error: precise_amount must be non-negative")
+		}
+		maxSafe := big.NewInt(1<<53 - 1)
+		if t.PreciseAmount.Cmp(maxSafe) <= 0 {
+			f, _ := new(big.Float).SetInt(t.PreciseAmount).Float64()
+			return splitLegTotal{float: f, mode: "float"}, nil
+		}
+		return splitLegTotal{bigInt: new(big.Int).Set(t.PreciseAmount), mode: "bigint"}, nil
+	}
+
+	return zero, errors.New("validation error: amount or precise_amount is required for split legs")
+}
+
+func validateSplitLegs(legs []Source, t CreateTransactionRequest, legLabel string) error {
+	total, err := resolveSplitLegTotal(t)
+	if err != nil {
+		return err
+	}
+
+	for _, leg := range legs {
+		if strings.TrimSpace(leg.Identifier) == "" {
+			return fmt.Errorf("validation error: each %s leg must include a valid identifier", legLabel)
+		}
+
+		hasDistribution := leg.Distribution != ""
+		hasPrecise := hasPreciseDistribution(leg)
+		if !hasDistribution && !hasPrecise {
+			return fmt.Errorf("validation error: each %s leg must include either 'distribution' or 'precise_distribution'", legLabel)
+		}
+	}
+
+	if total.mode == "bigint" {
+		return validateSplitLegsBigInt(legs, total.bigInt)
+	}
+	return validateSplitLegsFloat(legs, total.float)
+}
+
+func validateSplitLegsBigInt(legs []Source, total *big.Int) error {
+	hasDecimalDistribution := false
+	for _, leg := range legs {
+		if legUsesDecimalDistribution(leg) {
+			hasDecimalDistribution = true
+			break
+		}
+	}
+
+	maxSafe := big.NewInt(1 << 53)
+	if hasDecimalDistribution && total.Cmp(maxSafe) > 0 {
+		return errors.New("validation error: decimal distribution values are not supported with precise amounts beyond Number.MAX_SAFE_INTEGER")
+	}
+
+	if hasDecimalDistribution && total.Cmp(maxSafe) <= 0 {
+		f, _ := new(big.Float).SetInt(total).Float64()
+		return validateSplitLegsFloat(legs, f)
+	}
+
+	sum := big.NewInt(0)
 	hasLeft := false
-	for _, source := range sources {
-		distribution := source.Distribution
-		//check if the distribution is valid
-		isValid := distribution.IsValid()
-		if !isValid {
-			sb.WriteString("invalid distribution: " + string(distribution))
-			return errors.New(sb.String())
+
+	for _, leg := range legs {
+		if hasPreciseDistribution(leg) {
+			preciseValue, ok := parsePreciseInteger(leg.PreciseDistribution)
+			if !ok {
+				return fmt.Errorf("validation error: invalid precise_distribution for leg: %s", leg.Identifier)
+			}
+			sum.Add(sum, preciseValue)
+			continue
+		}
+
+		distribution := leg.Distribution
+		if !distribution.IsValid() {
+			return fmt.Errorf("validation error: invalid distribution type for leg: %s", leg.Identifier)
 		}
 
 		switch {
 		case distribution.IsPercentage():
-			// Get float value from percentage
 			percentage := distribution.ToPercentage()
-			v := (percentage / 100) * amount
-			if v < 0 {
-				sb.WriteString("invalid distribution in source: " + source.Identifier)
-				return errors.New(sb.String())
+			if percentage < 0 || percentage > 100 {
+				return fmt.Errorf("validation error: invalid percentage value in leg: %s", leg.Identifier)
 			}
-			total += v
-
-		case distribution.IsNumber():
-			// Get float value from number
-			number := distribution.ToNumber()
-			if number < 0 {
-				sb.WriteString("invalid distribution in source: " + source.Identifier)
-				return errors.New(sb.String())
-			}
-			total += number
+			pct := big.NewInt(int64(percentage))
+			part := new(big.Int).Mul(total, pct)
+			part.Div(part, big.NewInt(100))
+			sum.Add(sum, part)
 
 		case distribution.IsLeft():
-			// Ensure "left" distribution is used only once
 			if hasLeft {
-				sb.WriteString("you cannot use left distribution more than once")
-				return errors.New(sb.String())
+				return errors.New("validation error: multiple 'left' distribution types are not allowed")
+			}
+			hasLeft = true
+
+		case distribution.IsNumber():
+			fixedAmount := distribution.ToNumber()
+			if fixedAmount < 0 || fixedAmount != math.Trunc(fixedAmount) {
+				return fmt.Errorf("validation error: invalid distribution type for leg: %s", leg.Identifier)
+			}
+			sum.Add(sum, big.NewInt(int64(fixedAmount)))
+
+		default:
+			return fmt.Errorf("validation error: invalid distribution type for leg: %s", leg.Identifier)
+		}
+	}
+
+	if hasLeft {
+		remaining := new(big.Int).Sub(total, sum)
+		if remaining.Sign() < 0 {
+			return errors.New("validation error: total distribution exceeds the specified amount")
+		}
+	} else if sum.Cmp(total) != 0 {
+		return fmt.Errorf("validation error: total distribution sum (%s) does not equal the specified amount (%s)", sum.String(), total.String())
+	}
+
+	return nil
+}
+
+func validateSplitLegsFloat(legs []Source, amount float64) error {
+	sum := 0.0
+	hasLeft := false
+
+	for _, leg := range legs {
+		if hasPreciseDistribution(leg) {
+			preciseValue, ok := parsePreciseInteger(leg.PreciseDistribution)
+			if !ok {
+				return fmt.Errorf("validation error: invalid precise_distribution for leg: %s", leg.Identifier)
+			}
+			maxSafe := big.NewInt(1 << 53)
+			if preciseValue.Cmp(maxSafe) > 0 {
+				return fmt.Errorf("validation error: invalid precise_distribution for leg: %s", leg.Identifier)
+			}
+			f, _ := new(big.Float).SetInt(preciseValue).Float64()
+			sum += f
+			continue
+		}
+
+		distribution := leg.Distribution
+		if !distribution.IsValid() {
+			return fmt.Errorf("validation error: invalid distribution: %s", distribution)
+		}
+
+		switch {
+		case distribution.IsPercentage():
+			percentage := distribution.ToPercentage()
+			if percentage < 0 || percentage > 100 {
+				return fmt.Errorf("validation error: invalid percentage value in leg: %s", leg.Identifier)
+			}
+			sum += (percentage / 100) * amount
+
+		case distribution.IsNumber():
+			number := distribution.ToNumber()
+			if number < 0 {
+				return fmt.Errorf("validation error: invalid distribution in source: %s", leg.Identifier)
+			}
+			sum += number
+
+		case distribution.IsLeft():
+			if hasLeft {
+				return errors.New("validation error: you cannot use left distribution more than once")
 			}
 			hasLeft = true
 
 		default:
-			sb.WriteString("unknown distribution type in source: " + source.Identifier)
-			// Handle invalid or unrecognized distribution
-			return errors.New(sb.String())
+			return fmt.Errorf("validation error: unknown distribution type in source: %s", leg.Identifier)
 		}
 	}
 
-	// If "left" distribution is used, calculate its value and add to total
 	if hasLeft {
-		left := amount - total
-		if left < 0 {
-			sb.WriteString("total amount of sources exceeds the amount")
-			return errors.New(sb.String())
+		remaining := amount - sum
+		if remaining < -distributionSumEpsilon {
+			return errors.New("validation error: total distribution exceeds the specified amount")
 		}
-		total += left
-	}
-
-	if total != amount {
-		sb.WriteString("total amount of sources must be equal to the amount")
-		return errors.New(sb.String())
+	} else if !distributionTotalsApproximatelyEqual(sum, amount) {
+		return errors.New("validation error: total amount of sources must be equal to the amount")
 	}
 
 	return nil
+}
+
+func distributionTotalsApproximatelyEqual(sum, amount float64) bool {
+	return math.Abs(sum-amount) <= distributionSumEpsilon
 }

--- a/validate_transactions.go
+++ b/validate_transactions.go
@@ -39,13 +39,13 @@ func ValidateCreateTransacation(t CreateTransactionRequest) error {
 		return errors.New(sb.String())
 	}
 
-	if len(t.Sources) > 0 {
+	if len(t.Sources) > 0 && shouldValidateSplitLegSums(t, t.Sources) {
 		if err := validateSplitLegs(t.Sources, t, "source"); err != nil {
 			return err
 		}
 	}
 
-	if len(t.Destinations) > 0 {
+	if len(t.Destinations) > 0 && shouldValidateSplitLegSums(t, t.Destinations) {
 		if err := validateSplitLegs(t.Destinations, t, "destination"); err != nil {
 			return err
 		}
@@ -121,6 +121,29 @@ func ValidateRefundTransaction(r RefundTransactionRequest) error {
 
 func hasPreciseDistribution(leg Source) bool {
 	return leg.PreciseDistribution != ""
+}
+
+func legsUsePreciseDistribution(legs []Source) bool {
+	for _, leg := range legs {
+		if hasPreciseDistribution(leg) {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldValidateSplitLegSums preserves pre-#71 behavior: when precise_amount is set
+// and no leg uses precise_distribution, Core remains the source of truth for
+// classic distribution splits. Validate sums only for amount-based splits or when
+// precise_distribution appears on any leg.
+func shouldValidateSplitLegSums(t CreateTransactionRequest, legs []Source) bool {
+	if legsUsePreciseDistribution(legs) {
+		return true
+	}
+	if t.PreciseAmount != nil && t.PreciseAmount.Cmp(big.NewInt(0)) != 0 {
+		return false
+	}
+	return true
 }
 
 func usesPreciseIntegerArithmetic(t CreateTransactionRequest) bool {

--- a/validate_transactions_test.go
+++ b/validate_transactions_test.go
@@ -139,3 +139,27 @@ func TestValidateCreateTransaction_ClassicDistributionStillWorks(t *testing.T) {
 	}
 	require.NoError(t, blnkgo.ValidateCreateTransacation(txn))
 }
+
+func TestValidateCreateTransaction_PreciseAmountWithClassicDistributionSkipsSumValidation(t *testing.T) {
+	// Pre-#71 behavior: when precise_amount is set without precise_distribution legs,
+	// SDK does not client-side validate distribution sums; Core is source of truth.
+	txn := baseSplitTxn()
+	txn.PreciseAmount = big.NewInt(100000)
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_fee", Distribution: "50%"},
+		{Identifier: "bln_recipient", Distribution: "left"},
+	}
+	require.NoError(t, blnkgo.ValidateCreateTransacation(txn))
+}
+
+func TestValidateCreateTransaction_PreciseAmountWithPreciseDistributionStillValidated(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.PreciseAmount = big.NewInt(10000)
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_merchant", PreciseDistribution: "9733"},
+		{Identifier: "bln_fee", PreciseDistribution: "300"},
+	}
+	err := blnkgo.ValidateCreateTransacation(txn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not equal")
+}

--- a/validate_transactions_test.go
+++ b/validate_transactions_test.go
@@ -1,0 +1,116 @@
+package blnkgo_test
+
+import (
+	"math/big"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func baseSplitTxn() blnkgo.CreateTransactionRequest {
+	return blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Precision:   100,
+			Reference:   "ref_split_001",
+			Description: "Split transaction",
+			Currency:    "USD",
+			Source:      "bln_source",
+		},
+	}
+}
+
+func TestValidateCreateTransaction_PreciseDistributionOnly(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.PreciseAmount = big.NewInt(10000)
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_merchant", PreciseDistribution: "9733"},
+		{Identifier: "bln_fee", PreciseDistribution: "267"},
+	}
+	require.NoError(t, blnkgo.ValidateCreateTransacation(txn))
+}
+
+func TestValidateCreateTransaction_PreciseDistributionWithAmount(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.Amount = 10000
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_merchant", PreciseDistribution: "9733"},
+		{Identifier: "bln_fee", PreciseDistribution: "267"},
+	}
+	require.NoError(t, blnkgo.ValidateCreateTransacation(txn))
+}
+
+func TestValidateCreateTransaction_MixedDecimalAndPreciseDistribution(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.Amount = 30000
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_a", Distribution: "33.33%"},
+		{Identifier: "bln_b", PreciseDistribution: "5000"},
+		{Identifier: "bln_c", Distribution: "left"},
+	}
+	require.NoError(t, blnkgo.ValidateCreateTransacation(txn))
+}
+
+func TestValidateCreateTransaction_PreciseDistributionSumMismatch(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.Amount = 10000
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_merchant", PreciseDistribution: "9733"},
+		{Identifier: "bln_fee", PreciseDistribution: "300"},
+	}
+	err := blnkgo.ValidateCreateTransacation(txn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not equal")
+}
+
+func TestValidateCreateTransaction_MissingDistributionFields(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.Amount = 1000
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_merchant"},
+	}
+	err := blnkgo.ValidateCreateTransacation(txn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "precise_distribution")
+}
+
+func TestValidateCreateTransaction_InvalidPreciseDistribution(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.Amount = 1000
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_alice", PreciseDistribution: "not-a-number"},
+	}
+	err := blnkgo.ValidateCreateTransacation(txn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid precise_distribution")
+}
+
+func TestValidateCreateTransaction_LargePreciseDistributionExactSum(t *testing.T) {
+	legA := "9007199254740992"
+	legB := "1"
+	total := "9007199254740993"
+
+	txn := baseSplitTxn()
+	txn.PreciseAmount = new(big.Int)
+	_, ok := txn.PreciseAmount.SetString(total, 10)
+	require.True(t, ok)
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_alice", PreciseDistribution: legA},
+		{Identifier: "bln_bob", PreciseDistribution: legB},
+	}
+	require.NoError(t, blnkgo.ValidateCreateTransacation(txn))
+
+	txn.Destinations[1].PreciseDistribution = "2"
+	err := blnkgo.ValidateCreateTransacation(txn)
+	require.Error(t, err)
+}
+
+func TestValidateCreateTransaction_ClassicDistributionStillWorks(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.Amount = 1000
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_fee", Distribution: "50%"},
+		{Identifier: "bln_recipient", Distribution: "left"},
+	}
+	require.NoError(t, blnkgo.ValidateCreateTransacation(txn))
+}

--- a/validate_transactions_test.go
+++ b/validate_transactions_test.go
@@ -105,6 +105,31 @@ func TestValidateCreateTransaction_LargePreciseDistributionExactSum(t *testing.T
 	require.Error(t, err)
 }
 
+func TestValidateCreateTransaction_NonIntegerAmountWithPreciseDistributionRejected(t *testing.T) {
+	txn := baseSplitTxn()
+	txn.Amount = 10000.50
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_merchant", PreciseDistribution: "9733"},
+		{Identifier: "bln_fee", PreciseDistribution: "267"},
+	}
+	err := blnkgo.ValidateCreateTransacation(txn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "whole number")
+}
+
+func TestValidateCreateTransaction_NonIntegerAmountTruncationWouldMismatch(t *testing.T) {
+	// 10000.99 truncates to 10000, which would incorrectly pass a 10001 split sum.
+	txn := baseSplitTxn()
+	txn.Amount = 10000.99
+	txn.Destinations = []blnkgo.Source{
+		{Identifier: "bln_merchant", PreciseDistribution: "9733"},
+		{Identifier: "bln_fee", PreciseDistribution: "268"},
+	}
+	err := blnkgo.ValidateCreateTransacation(txn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "whole number")
+}
+
 func TestValidateCreateTransaction_ClassicDistributionStillWorks(t *testing.T) {
 	txn := baseSplitTxn()
 	txn.Amount = 1000


### PR DESCRIPTION
## Summary
- Adds `PreciseDistribution` (`precise_distribution`) to `Source` for split transaction legs on `Transaction.Create`
- Extends split-leg validation to accept `distribution` or `precise_distribution`, including bigint arithmetic for large precise sums and mixed decimal/% + precise + left legs (parity with TS SDK)
- Adds unit tests, integration tests against Core 0.14.5, and Postman folder **Issue #71 — precise_distribution split legs** (synced to cloud collection)

Closes #71

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -v ./integration/... -run Issue71` (local Core 0.14.5)
- [x] Postman folder **Issue #71** in `Blnk Go SDK — Local Core Tests` (cloud collection updated)