### PR TITLE
Add skip_queue to inflight update and bulk commit/void (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ transaction, resp, err := client.Transaction.Create(inflightBody)
 #### Committing or Voiding an Inflight Transaction
 
 ```go
-// Commit the transaction
+// Commit the transaction (queued by default on Core 0.15.0+)
 updateBody := blnkgo.UpdateStatus{
     Status: blnkgo.InflightStatusCommit,
 }
@@ -421,6 +421,17 @@ updateBody := blnkgo.UpdateStatus{
 updatedTransaction, resp, err := client.Transaction.Update(
     "txn_id_here",
     updateBody,
+)
+
+// Synchronous commit (skip_queue: true) — returns APPLIED immediately
+syncCommitBody := blnkgo.UpdateStatus{
+    Status:    blnkgo.InflightStatusCommit,
+    SkipQueue: true,
+}
+
+syncCommitted, resp, err := client.Transaction.Update(
+    "txn_id_here",
+    syncCommitBody,
 )
 
 // Or void the transaction
@@ -432,6 +443,12 @@ voidedTransaction, resp, err := client.Transaction.Update(
     "txn_id_here",
     voidBody,
 )
+
+// Synchronous void
+syncVoidBody := blnkgo.UpdateStatus{
+    Status:    blnkgo.InflightStatusVoid,
+    SkipQueue: true,
+}
 ```
 
 #### Bulk Commit Inflight Transactions
@@ -440,6 +457,7 @@ Commit multiple independently-created inflight transactions in a single call:
 
 ```go
 bulkCommitBody := blnkgo.BulkCommitInflightRequest{
+    SkipQueue: true, // optional: process synchronously without queuing
     Transactions: []blnkgo.BulkCommitInflightItem{
         {TransactionID: "txn_id_1"},
         {TransactionID: "txn_id_2", Amount: 40},
@@ -465,6 +483,7 @@ Void multiple independently-created inflight transactions in a single call:
 
 ```go
 bulkVoidBody := blnkgo.BulkVoidInflightRequest{
+    SkipQueue: true, // optional: process synchronously without queuing
     TransactionIDs: []string{
         "txn_id_1",
         "txn_id_2",

--- a/integration/README.md
+++ b/integration/README.md
@@ -13,6 +13,7 @@ export BLNK_API_KEY=your_master_or_api_key
 ```bash
 # one issue
 go test -tags=integration -v ./integration/... -run Issue70
+go test -tags=integration -v ./integration/... -run Issue86
 go test -tags=integration -v ./integration/... -run Issue71
 go test -tags=integration -v ./integration/... -run Issue40
 go test -tags=integration -v ./integration/... -run Issue73
@@ -37,6 +38,7 @@ go test -tags=integration -v ./integration/...
 | #40 recover queue | 0.14.x+ | Not 0.15-only |
 | #70 refund skip_queue | 0.14.x+ | Optional body on POST /refund-transaction/{id} |
 | #71 precise_distribution | 0.14.x+ | Split legs with precise_distribution on POST /transactions |
+| #86 update skip_queue | 0.14.x+ | skip_queue on inflight commit/void (Update + bulk) |
 | #73 search identities | 0.14.x+ | Not 0.15-only |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |

--- a/integration/issue86_test.go
+++ b/integration/issue86_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+// Integration tests for issue #86 — skip_queue on inflight commit/void (UpdateStatus + bulk).
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue86
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func createInflightTxnIssue86(t *testing.T, client *blnkgo.Client, ref string) string {
+	t.Helper()
+	expiry := time.Now().Add(24 * time.Hour)
+	txn, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      5000,
+			Reference:   ref,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Destination: "@Recipient",
+			Description: "Issue 86 inflight setup",
+			SkipQueue:   true,
+		},
+		Inflight:           true,
+		InflightExpiryDate: &expiry,
+		AllowOverdraft:     true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, txn.TransactionID)
+	return txn.TransactionID
+}
+
+func TestIssue86_UpdateStatus_SkipQueueSynchronousCommit(t *testing.T) {
+	client := newIntegrationClient(t)
+	ref := fmt.Sprintf("issue86-sync-commit-%d", time.Now().UnixNano())
+	txnID := createInflightTxnIssue86(t, client, ref)
+
+	committed, resp, err := client.Transaction.Update(txnID, blnkgo.UpdateStatus{
+		Status:    blnkgo.InflightStatusCommit,
+		SkipQueue: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, blnkgo.PryTransactionStatus("APPLIED"), committed.Status)
+	require.False(t, committed.Queued)
+}
+
+func TestIssue86_UpdateStatus_QueuedDefaultCommit(t *testing.T) {
+	client := newIntegrationClient(t)
+	ref := fmt.Sprintf("issue86-queued-commit-%d", time.Now().UnixNano())
+	txnID := createInflightTxnIssue86(t, client, ref)
+
+	committed, resp, err := client.Transaction.Update(txnID, blnkgo.UpdateStatus{
+		Status: blnkgo.InflightStatusCommit,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Core 0.15+ queues commit by default (queued:true, status INFLIGHT).
+	// Core 0.14.x may apply synchronously (APPLIED). Accept either contract.
+	if committed.Queued {
+		require.Equal(t, blnkgo.PryTransactionStatus("INFLIGHT"), committed.Status)
+	} else {
+		require.Equal(t, blnkgo.PryTransactionStatus("APPLIED"), committed.Status)
+	}
+}
+
+func TestIssue86_UpdateStatus_SkipQueueSynchronousVoid(t *testing.T) {
+	client := newIntegrationClient(t)
+	ref := fmt.Sprintf("issue86-sync-void-%d", time.Now().UnixNano())
+	txnID := createInflightTxnIssue86(t, client, ref)
+
+	voided, resp, err := client.Transaction.Update(txnID, blnkgo.UpdateStatus{
+		Status:    blnkgo.InflightStatusVoid,
+		SkipQueue: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, blnkgo.PryTransactionStatus("VOID"), voided.Status)
+}
+
+func TestIssue86_BulkCommitInflight_SkipQueue(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	syncID := createInflightTxnIssue86(t, client, fmt.Sprintf("issue86-bulk-sync-%s", suffix))
+
+	result, resp, err := client.Transaction.BulkCommitInflight(blnkgo.BulkCommitInflightRequest{
+		SkipQueue: true,
+		Transactions: []blnkgo.BulkCommitInflightItem{
+			{TransactionID: syncID},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 1, result.Succeeded)
+	require.Equal(t, "succeeded", result.Results[0].Status)
+}
+
+func TestIssue86_BulkVoidInflight_SkipQueue(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	syncID := createInflightTxnIssue86(t, client, fmt.Sprintf("issue86-bulk-void-%s", suffix))
+
+	result, resp, err := client.Transaction.BulkVoidInflight(blnkgo.BulkVoidInflightRequest{
+		SkipQueue:      true,
+		TransactionIDs: []string{syncID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 1, result.Succeeded)
+	require.Equal(t, "succeeded", result.Results[0].Status)
+}

--- a/postman/README.md
+++ b/postman/README.md
@@ -21,6 +21,7 @@ Import these two files into Postman (one-time):
 | **Issue #40 — RecoverQueue** | `POST /transactions/recover` | 0.14.5+ |
 | **Issue #70 — Refund skip_queue** | `POST /refund-transaction/{id}` | 0.14.5+ |
 | **Issue #71 — precise_distribution** | `POST /transactions` split legs | 0.14.5+ |
+| **Issue #86 — Update skip_queue** | `PUT /transactions/inflight/{id}` + bulk commit/void | 0.14.5+ |
 
 ## CLI (same tests, no Postman UI)
 

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Blnk Go SDK — Local Core Tests",
-    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #71 — precise_distribution split legs\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
+    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #86 — UpdateStatus skip_queue\n- Issue #71 — precise_distribution split legs\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -43,6 +43,14 @@
     },
     {
       "key": "issue71_balance_c",
+      "value": ""
+    },
+    {
+      "key": "issue86_inflight_txn_id",
+      "value": ""
+    },
+    {
+      "key": "issue86_void_txn_id",
       "value": ""
     }
   ],
@@ -265,6 +273,160 @@
             },
             "url": "{{blnk_base_url}}/refund-transaction/{{refund_sync_source_txn_id}}",
             "description": "Go SDK: Transaction.Refund(id, &RefundTransactionRequest{SkipQueue: true})"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Issue #86 — UpdateStatus skip_queue",
+      "item": [
+        {
+          "name": "1. Create inflight transaction (seed)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('issue86_commit_ref', `issue86-commit-${Date.now()}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.expect(json.status).to.eql('INFLIGHT');",
+                  "pm.collectionVariables.set('issue86_inflight_txn_id', json.transaction_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 5000,\n  \"reference\": \"{{issue86_commit_ref}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"@FundingPool\",\n  \"destination\": \"@Recipient\",\n  \"skip_queue\": true,\n  \"inflight\": true,\n  \"inflight_expiry_date\": \"2026-12-31T23:59:59Z\",\n  \"allow_overdraft\": true,\n  \"description\": \"Go SDK issue 86 commit seed\"\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions"
+          }
+        },
+        {
+          "name": "2. Commit inflight (skip_queue synchronous)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('commit applied synchronously', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.status).to.eql('APPLIED');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"commit\",\n  \"skip_queue\": true\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions/inflight/{{issue86_inflight_txn_id}}",
+            "description": "Go SDK: Transaction.Update(id, UpdateStatus{Status: commit, SkipQueue: true})"
+          }
+        },
+        {
+          "name": "3. Create inflight transaction (void seed)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('issue86_void_ref', `issue86-void-${Date.now()}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('issue86_void_txn_id', json.transaction_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 5000,\n  \"reference\": \"{{issue86_void_ref}}\",\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"@FundingPool\",\n  \"destination\": \"@Recipient\",\n  \"skip_queue\": true,\n  \"inflight\": true,\n  \"inflight_expiry_date\": \"2026-12-31T23:59:59Z\",\n  \"allow_overdraft\": true,\n  \"description\": \"Go SDK issue 86 void seed\"\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions"
+          }
+        },
+        {
+          "name": "4. Void inflight (skip_queue synchronous)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('void applied synchronously', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.status).to.eql('VOID');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"void\",\n  \"skip_queue\": true\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions/inflight/{{issue86_void_txn_id}}",
+            "description": "Go SDK: Transaction.Update(id, UpdateStatus{Status: void, SkipQueue: true})"
           }
         }
       ]

--- a/transaction.go
+++ b/transaction.go
@@ -50,12 +50,14 @@ type Transaction struct {
 	CreatedAt           time.Time `json:"created_at"`
 	TransactionID       string    `json:"transaction_id"`
 	ParentTransactionID string    `json:"parent_transaction,omitempty"`
+	Queued              bool      `json:"queued,omitempty"`
 }
 
 type UpdateStatus struct {
 	Status        InflightStatus `json:"status"`
 	Amount        float64        `json:"amount"`
 	PreciseAmount *big.Int       `json:"precise_amount"`
+	SkipQueue     bool           `json:"skip_queue,omitempty"`
 }
 
 type CreateBulkTransactionRequest struct {
@@ -96,6 +98,7 @@ type BulkCommitInflightItem struct {
 // transactions in one call.
 type BulkCommitInflightRequest struct {
 	Transactions []BulkCommitInflightItem `json:"transactions"`
+	SkipQueue    bool                     `json:"skip_queue,omitempty"`
 }
 
 // BulkCommitInflightResult is the per-item outcome in BulkCommitInflightResponse.
@@ -117,6 +120,7 @@ type BulkCommitInflightResponse struct {
 // transactions in one call.
 type BulkVoidInflightRequest struct {
 	TransactionIDs []string `json:"transaction_ids"`
+	SkipQueue      bool     `json:"skip_queue,omitempty"`
 }
 
 // BulkVoidInflightResult is the per-item outcome in BulkVoidInflightResponse.

--- a/transaction_bulk_commit_inflight_test.go
+++ b/transaction_bulk_commit_inflight_test.go
@@ -141,3 +141,42 @@ func TestTransactionService_BulkCommitInflight_ServerError(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	mockClient.AssertExpectations(t)
 }
+
+func TestTransactionService_BulkCommitInflight_WithSkipQueue(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	body := blnkgo.BulkCommitInflightRequest{
+		SkipQueue: true,
+		Transactions: []blnkgo.BulkCommitInflightItem{
+			{TransactionID: "txn_11111111-1111-4111-8111-111111111111"},
+		},
+	}
+
+	mockClient.On(
+		"NewRequest",
+		"transactions/inflight/bulk/commit",
+		http.MethodPost,
+		mock.MatchedBy(func(req interface{}) bool {
+			bulk, ok := req.(blnkgo.BulkCommitInflightRequest)
+			return ok && bulk.SkipQueue && len(bulk.Transactions) == 1
+		}),
+	).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		response := args.Get(1).(*blnkgo.BulkCommitInflightResponse)
+		*response = blnkgo.BulkCommitInflightResponse{
+			Succeeded: 1,
+			Results: []blnkgo.BulkCommitInflightResult{
+				{TransactionID: "txn_11111111-1111-4111-8111-111111111111", Status: "succeeded"},
+			},
+		}
+	})
+
+	result, resp, err := svc.BulkCommitInflight(body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 1, result.Succeeded)
+	assert.Equal(t, "succeeded", result.Results[0].Status)
+	mockClient.AssertExpectations(t)
+}

--- a/transaction_bulk_void_inflight_test.go
+++ b/transaction_bulk_void_inflight_test.go
@@ -137,3 +137,40 @@ func TestTransactionService_BulkVoidInflight_ServerError(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	mockClient.AssertExpectations(t)
 }
+
+func TestTransactionService_BulkVoidInflight_WithSkipQueue(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	body := blnkgo.BulkVoidInflightRequest{
+		SkipQueue:      true,
+		TransactionIDs: []string{"txn_11111111-1111-4111-8111-111111111111"},
+	}
+
+	mockClient.On(
+		"NewRequest",
+		"transactions/inflight/bulk/void",
+		http.MethodPost,
+		mock.MatchedBy(func(req interface{}) bool {
+			bulk, ok := req.(blnkgo.BulkVoidInflightRequest)
+			return ok && bulk.SkipQueue && len(bulk.TransactionIDs) == 1
+		}),
+	).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		response := args.Get(1).(*blnkgo.BulkVoidInflightResponse)
+		*response = blnkgo.BulkVoidInflightResponse{
+			Succeeded: 1,
+			Results: []blnkgo.BulkVoidInflightResult{
+				{TransactionID: "txn_11111111-1111-4111-8111-111111111111", Status: "succeeded"},
+			},
+		}
+	})
+
+	result, resp, err := svc.BulkVoidInflight(body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 1, result.Succeeded)
+	assert.Equal(t, "succeeded", result.Results[0].Status)
+	mockClient.AssertExpectations(t)
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -515,6 +515,69 @@ func TestRefundTransaction_WithSkipQueue(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestUpdateStatus_WithSkipQueue(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	body := blnkgo.UpdateStatus{
+		Status:    blnkgo.InflightStatusCommit,
+		SkipQueue: true,
+	}
+
+	mockClient.On(
+		"NewRequest",
+		"transactions/inflight/txn-inflight-1",
+		http.MethodPut,
+		mock.MatchedBy(func(req interface{}) bool {
+			update, ok := req.(blnkgo.UpdateStatus)
+			return ok && update.SkipQueue && update.Status == blnkgo.InflightStatusCommit
+		}),
+	).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		transaction := args.Get(1).(*blnkgo.Transaction)
+		*transaction = blnkgo.Transaction{
+			TransactionID: "txn-inflight-1",
+			ParentTransaction: blnkgo.ParentTransaction{
+				Status: blnkgo.PryTransactionStatus("APPLIED"),
+			},
+		}
+	})
+
+	result, resp, err := svc.Update("txn-inflight-1", body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, blnkgo.PryTransactionStatus("APPLIED"), result.Status)
+	mockClient.AssertExpectations(t)
+}
+
+func TestUpdateStatus_SkipQueueJSONMarshal(t *testing.T) {
+	body := blnkgo.UpdateStatus{
+		Status:    blnkgo.InflightStatusCommit,
+		SkipQueue: true,
+	}
+	data, err := json.Marshal(body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"skip_queue":true`)
+}
+
+func TestTransaction_Queued_UnmarshalJSON(t *testing.T) {
+	payload := []byte(`{
+		"transaction_id": "txn_queued_commit",
+		"status": "INFLIGHT",
+		"queued": true
+	}`)
+
+	var txn blnkgo.Transaction
+	err := json.Unmarshal(payload, &txn)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "txn_queued_commit", txn.TransactionID)
+	assert.True(t, txn.Queued)
+	assert.Equal(t, blnkgo.PryTransactionStatus("INFLIGHT"), txn.Status)
+}
+
 func TestRefundTransaction_EmptyTransactionID(t *testing.T) {
 	mockClient, svc := setupTransactionService()
 


### PR DESCRIPTION
## Summary
- Adds `SkipQueue` to `UpdateStatus`, `BulkCommitInflightRequest`, and `BulkVoidInflightRequest` so Go callers can pass `skip_queue` on inflight commit/void (parity with TS SDK #117 and Core 0.15.0+)
- Adds `Queued` on `Transaction` response for queued commit/void outcomes
- Unit tests for request body forwarding + JSON marshal; integration tests for sync commit/void and bulk paths
- Postman folder **Issue #86 — UpdateStatus skip_queue** (synced to cloud collection); README inflight examples updated

Closes #86

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -v ./integration/... -run Issue86` (local Core 0.14.5)
- [x] Postman folder **Issue #86** in `Blnk Go SDK — Local Core Tests` (cloud collection updated)