### PR TITLE
Add from_source query support to LedgerBalance.Get (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,24 @@ if err != nil {
 fmt.Printf("Balance Created: %+v\n", newBalance)
 ```
 
+### Retrieving a Balance (from source)
+
+By default, `Get` returns the stored balance snapshot. Pass `from_source: true` to reconstruct the balance from all transactions instead:
+
+```go
+balance, resp, err := client.LedgerBalance.Get(newBalance.BalanceID, &blnkgo.GetBalanceRequest{
+    FromSource: true,
+})
+if err != nil {
+    fmt.Printf("Error fetching balance from source: %v\n", err)
+    return
+}
+
+fmt.Printf("Balance from source: %+v\n", balance)
+```
+
+Existing callers can keep using `client.LedgerBalance.Get(balanceID)` with no second argument.
+
 ### Viewing Balance Lineage
 
 For balances with fund lineage tracking enabled, retrieve the provider breakdown (received, spent, available):

--- a/integration/README.md
+++ b/integration/README.md
@@ -14,6 +14,7 @@ export BLNK_API_KEY=your_master_or_api_key
 # one issue
 go test -tags=integration -v ./integration/... -run Issue70
 go test -tags=integration -v ./integration/... -run Issue86
+go test -tags=integration -v ./integration/... -run Issue69
 go test -tags=integration -v ./integration/... -run Issue71
 go test -tags=integration -v ./integration/... -run Issue40
 go test -tags=integration -v ./integration/... -run Issue73
@@ -39,6 +40,7 @@ go test -tags=integration -v ./integration/...
 | #70 refund skip_queue | 0.14.x+ | Optional body on POST /refund-transaction/{id} |
 | #71 precise_distribution | 0.14.x+ | Split legs with precise_distribution on POST /transactions |
 | #86 update skip_queue | 0.14.x+ | skip_queue on inflight commit/void (Update + bulk) |
+| #69 balance from_source | 0.14.x+ | GET /balances/{id}?from_source=true |
 | #73 search identities | 0.14.x+ | Not 0.15-only |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |

--- a/integration/issue69_test.go
+++ b/integration/issue69_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+// Integration tests for issue #69 — LedgerBalance.Get from_source query param.
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue69
+package integration
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue69_GetBalance_FromSourceMatchesSnapshot(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "FromSource " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	source, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	dest, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	_, resp, err = client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      500,
+			Reference:   "from-source-" + suffix,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      source.BalanceID,
+			Destination: dest.BalanceID,
+			SkipQueue:   true,
+			Description: "Fund destination for from_source test",
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	snapshot, resp, err := client.LedgerBalance.Get(dest.BalanceID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	fromSource, resp, err := client.LedgerBalance.Get(dest.BalanceID, &blnkgo.GetBalanceRequest{FromSource: true})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Equal(t, dest.BalanceID, fromSource.BalanceID)
+	require.Equal(t, 0, snapshot.Balance.Cmp(fromSource.Balance))
+	require.Equal(t, 0, snapshot.CreditBalance.Cmp(fromSource.CreditBalance))
+	require.Equal(t, 0, snapshot.DebitBalance.Cmp(fromSource.DebitBalance))
+	require.True(t, fromSource.Balance.Cmp(big.NewInt(0)) > 0, "destination should be credited")
+}
+
+func TestIssue69_GetBalance_BackwardCompatibleNoOptions(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "GetCompat " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	bal, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	got, resp, err := client.LedgerBalance.Get(bal.BalanceID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, bal.BalanceID, got.BalanceID)
+}

--- a/ledger_balance.go
+++ b/ledger_balance.go
@@ -38,6 +38,12 @@ type CreateLedgerBalanceRequest struct {
 	MetaData   map[string]interface{} `json:"meta_data,omitempty"`
 }
 
+// GetBalanceRequest holds optional query parameters for LedgerBalance.Get.
+type GetBalanceRequest struct {
+	// FromSource reconstructs the balance from transactions instead of snapshots.
+	FromSource bool `json:"from_source,omitempty"`
+}
+
 func (s *LedgerBalanceService) Create(body CreateLedgerBalanceRequest) (*LedgerBalance, *http.Response, error) {
 	req, err := s.client.NewRequest("balances", http.MethodPost, body)
 	if err != nil {
@@ -53,11 +59,17 @@ func (s *LedgerBalanceService) Create(body CreateLedgerBalanceRequest) (*LedgerB
 	return ledgerBalance, resp, nil
 }
 
-func (s *LedgerBalanceService) Get(balanceID string) (*LedgerBalance, *http.Response, error) {
+func (s *LedgerBalanceService) Get(balanceID string, opts ...*GetBalanceRequest) (*LedgerBalance, *http.Response, error) {
 	if balanceID == "" {
 		return nil, nil, fmt.Errorf("invalid: id is required")
 	}
+	if len(opts) > 1 {
+		return nil, nil, fmt.Errorf("Get accepts at most one optional request")
+	}
 	u := fmt.Sprintf("balances/%s", balanceID)
+	if len(opts) > 0 && opts[0] != nil && opts[0].FromSource {
+		u += "?from_source=true"
+	}
 	req, err := s.client.NewRequest(u, http.MethodGet, nil)
 	if err != nil {
 		return nil, nil, err

--- a/ledger_balance_test.go
+++ b/ledger_balance_test.go
@@ -145,6 +145,55 @@ func TestLedgerBalanceService_Get_EmptyID(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestLedgerBalanceService_Get_WithFromSource(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "balance123"
+	expectedEndpoint := fmt.Sprintf("balances/%s?from_source=true", balanceID)
+
+	mockClient.On("NewRequest", expectedEndpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, resp, err := svc.Get(balanceID, &blnkgo.GetBalanceRequest{FromSource: true})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	mockClient.AssertCalled(t, "NewRequest", expectedEndpoint, http.MethodGet, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_Get_BackwardCompatibleNoOptions(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "balance123"
+	expectedEndpoint := fmt.Sprintf("balances/%s", balanceID)
+
+	mockClient.On("NewRequest", expectedEndpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, _, err := svc.Get(balanceID)
+
+	assert.NoError(t, err)
+	mockClient.AssertCalled(t, "NewRequest", expectedEndpoint, http.MethodGet, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_Get_RejectsMultipleOptions(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+
+	_, resp, err := svc.Get("balance123",
+		&blnkgo.GetBalanceRequest{FromSource: true},
+		&blnkgo.GetBalanceRequest{FromSource: false},
+	)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+}
+
 func TestLedgerBalanceService_GetByIndicator(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/postman/README.md
+++ b/postman/README.md
@@ -22,6 +22,7 @@ Import these two files into Postman (one-time):
 | **Issue #70 — Refund skip_queue** | `POST /refund-transaction/{id}` | 0.14.5+ |
 | **Issue #71 — precise_distribution** | `POST /transactions` split legs | 0.14.5+ |
 | **Issue #86 — Update skip_queue** | `PUT /transactions/inflight/{id}` + bulk commit/void | 0.14.5+ |
+| **Issue #69 — Balance from_source** | `GET /balances/{id}?from_source=true` | 0.14.5+ |
 
 ## CLI (same tests, no Postman UI)
 

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -466,7 +466,7 @@
           }
         },
         {
-          "name": "2. Create balances (source + dest)",
+          "name": "2. Create source balance",
           "event": [
             {
               "listen": "test",
@@ -478,12 +478,7 @@
                   "});",
                   "",
                   "const json = pm.response.json();",
-                  "if (!pm.collectionVariables.get('issue69_source_id')) {",
-                  "    pm.collectionVariables.set('issue69_source_id', json.balance_id);",
-                  "    postman.setNextRequest('2. Create balances (source + dest)');",
-                  "} else {",
-                  "    pm.collectionVariables.set('issue69_dest_id', json.balance_id);",
-                  "}"
+                  "pm.collectionVariables.set('issue69_source_id', json.balance_id);"
                 ]
               }
             }
@@ -502,7 +497,38 @@
           }
         },
         {
-          "name": "3. Fund destination",
+          "name": "3. Create destination balance",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('issue69_dest_id', json.balance_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ledger_id\": \"{{issue69_ledger_id}}\",\n  \"currency\": \"USD\"\n}"
+            },
+            "url": "{{blnk_base_url}}/balances"
+          }
+        },
+        {
+          "name": "4. Fund destination",
           "event": [
             {
               "listen": "test",
@@ -530,7 +556,7 @@
           }
         },
         {
-          "name": "4. GET balance from_source",
+          "name": "5. GET balance from_source",
           "event": [
             {
               "listen": "test",

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Blnk Go SDK — Local Core Tests",
-    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #86 — UpdateStatus skip_queue\n- Issue #71 — precise_distribution split legs\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
+    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #86 — UpdateStatus skip_queue\n- Issue #69 — LedgerBalance.Get from_source\n- Issue #71 — precise_distribution split legs\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -427,6 +427,141 @@
             },
             "url": "{{blnk_base_url}}/transactions/inflight/{{issue86_void_txn_id}}",
             "description": "Go SDK: Transaction.Update(id, UpdateStatus{Status: void, SkipQueue: true})"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Issue #69 — Balance Get from_source",
+      "item": [
+        {
+          "name": "1. Create ledger",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('issue69_ledger_id', json.ledger_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Go SDK Issue 69\"\n}"
+            },
+            "url": "{{blnk_base_url}}/ledgers"
+          }
+        },
+        {
+          "name": "2. Create balances (source + dest)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "if (!pm.collectionVariables.get('issue69_source_id')) {",
+                  "    pm.collectionVariables.set('issue69_source_id', json.balance_id);",
+                  "    postman.setNextRequest('2. Create balances (source + dest)');",
+                  "} else {",
+                  "    pm.collectionVariables.set('issue69_dest_id', json.balance_id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ledger_id\": \"{{issue69_ledger_id}}\",\n  \"currency\": \"USD\"\n}"
+            },
+            "url": "{{blnk_base_url}}/balances"
+          }
+        },
+        {
+          "name": "3. Fund destination",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 500,\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"{{issue69_source_id}}\",\n  \"destination\": \"{{issue69_dest_id}}\",\n  \"reference\": \"issue69-fund\",\n  \"allow_overdraft\": true,\n  \"skip_queue\": true\n}"
+            },
+            "url": "{{blnk_base_url}}/transactions"
+          }
+        },
+        {
+          "name": "4. GET balance from_source",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('balance_id matches destination', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.balance_id).to.eql(pm.collectionVariables.get('issue69_dest_id'));",
+                  "});",
+                  "",
+                  "pm.test('credited balance is positive', function () {",
+                  "    const json = pm.response.json();",
+                  "    pm.expect(json.balance).to.be.above(0);",
+                  "    pm.expect(json.credit_balance).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
+            ],
+            "url": "{{blnk_base_url}}/balances/{{issue69_dest_id}}?from_source=true",
+            "description": "Go SDK: LedgerBalance.Get(balanceID, &GetBalanceRequest{FromSource: true})"
           }
         }
       ]

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -531,6 +531,15 @@
           "name": "4. Fund destination",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('issue69_ref', `issue69-fund-${Date.now()}`);"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -550,7 +559,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"amount\": 500,\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"{{issue69_source_id}}\",\n  \"destination\": \"{{issue69_dest_id}}\",\n  \"reference\": \"issue69-fund\",\n  \"allow_overdraft\": true,\n  \"skip_queue\": true\n}"
+              "raw": "{\n  \"amount\": 500,\n  \"precision\": 100,\n  \"currency\": \"USD\",\n  \"source\": \"{{issue69_source_id}}\",\n  \"destination\": \"{{issue69_dest_id}}\",\n  \"reference\": \"{{issue69_ref}}\",\n  \"description\": \"Issue #69 fund destination\",\n  \"allow_overdraft\": true,\n  \"skip_queue\": true\n}"
             },
             "url": "{{blnk_base_url}}/transactions"
           }


### PR DESCRIPTION
## Summary
- Adds `GetBalanceRequest` with optional `FromSource` for `GET /balances/{id}?from_source=true` (parity with TS SDK #48 and [balance-from-source reference](https://docs.blnkfinance.com/reference/balance-from-source))
- Uses variadic optional request so existing `Get(balanceID)` callers compile unchanged
- Unit tests for query forwarding, backward compatibility, and multiple-options guard
- Integration tests compare snapshot vs from_source balances after a funded transaction
- Postman folder **Issue #69 — Balance Get from_source** (synced to cloud collection); README example added

Closes #69

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -v ./integration/... -run Issue69` (local Core 0.14.5)
- [x] Postman folder **Issue #69** in `Blnk Go SDK — Local Core Tests` (cloud collection updated)