### PR TITLE
Add track_fund_lineage and allocation_strategy to balance create (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ if err != nil {
 fmt.Printf("Balance Created: %+v\n", newBalance)
 ```
 
+To enable fund lineage tracking on create, set `track_fund_lineage` (requires `identity_id`) and optionally `allocation_strategy`:
+
+```go
+balanceBody := blnkgo.CreateLedgerBalanceRequest{
+    LedgerID:           "ldg_073f7ffe-9dfd-42ce-aa50-d1dca1788adc",
+    IdentityID:         "idt_3b63c8da-af29-4cc3-ad38-df17d87456e6",
+    Currency:           "USD",
+    TrackFundLineage:   true,
+    AllocationStrategy: blnkgo.AllocationStrategyFIFO, // FIFO | LIFO | PROPORTIONAL
+}
+
+lineageBalance, resp, err := client.LedgerBalance.Create(balanceBody)
+```
+
 ### Viewing Balance Lineage
 
 For balances with fund lineage tracking enabled, retrieve the provider breakdown (received, spent, available):

--- a/integration/README.md
+++ b/integration/README.md
@@ -14,6 +14,7 @@ export BLNK_API_KEY=your_master_or_api_key
 # one issue
 go test -tags=integration -v ./integration/... -run Issue70
 go test -tags=integration -v ./integration/... -run Issue86
+go test -tags=integration -v ./integration/... -run Issue68
 go test -tags=integration -v ./integration/... -run Issue71
 go test -tags=integration -v ./integration/... -run Issue40
 go test -tags=integration -v ./integration/... -run Issue73
@@ -39,6 +40,7 @@ go test -tags=integration -v ./integration/...
 | #70 refund skip_queue | 0.14.x+ | Optional body on POST /refund-transaction/{id} |
 | #71 precise_distribution | 0.14.x+ | Split legs with precise_distribution on POST /transactions |
 | #86 update skip_queue | 0.14.x+ | skip_queue on inflight commit/void (Update + bulk) |
+| #68 balance lineage create | 0.14.x+ | track_fund_lineage + allocation_strategy on POST /balances |
 | #73 search identities | 0.14.x+ | Not 0.15-only |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |

--- a/integration/issue68_test.go
+++ b/integration/issue68_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+// Integration tests for issue #68 — LedgerBalance.Create track_fund_lineage + allocation_strategy.
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue68
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue68_CreateBalance_WithLineageFields(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	dob := time.Date(1990, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "Lineage Create " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	identity, resp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Lineage",
+		LastName:     "Balance",
+		EmailAddress: fmt.Sprintf("issue68-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+		DOB:          &dob,
+		Gender:       "Male",
+		Nationality:  "American",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, identity.IdentityId)
+
+	bal, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:           ledger.LedgerID,
+		IdentityID:         identity.IdentityId,
+		Currency:           "USD",
+		TrackFundLineage:   true,
+		AllocationStrategy: blnkgo.AllocationStrategyPROPORTIONAL,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.True(t, bal.TrackFundLineage)
+	require.Equal(t, blnkgo.AllocationStrategyPROPORTIONAL, bal.AllocationStrategy)
+	require.Equal(t, identity.IdentityId, bal.IdentityID)
+
+	got, resp, err := client.LedgerBalance.Get(bal.BalanceID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.True(t, got.TrackFundLineage)
+	require.Equal(t, blnkgo.AllocationStrategyPROPORTIONAL, got.AllocationStrategy)
+}
+
+func TestIssue68_CreateBalance_AllocationStrategyOnly(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "Alloc Only " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	bal, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:           ledger.LedgerID,
+		Currency:           "USD",
+		AllocationStrategy: blnkgo.AllocationStrategyFIFO,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.Equal(t, blnkgo.AllocationStrategyFIFO, bal.AllocationStrategy)
+}

--- a/ledger_balance.go
+++ b/ledger_balance.go
@@ -29,16 +29,25 @@ type LedgerBalance struct {
 	CreatedAt             time.Time              `json:"created_at"`
 	InflightExpiresAt     time.Time              `json:"inflight_expires_at"`
 	MetaData              map[string]interface{} `json:"meta_data,omitempty"`
+	TrackFundLineage      bool                   `json:"track_fund_lineage,omitempty"`
+	AllocationStrategy    AllocationStrategy     `json:"allocation_strategy,omitempty"`
 }
 
 type CreateLedgerBalanceRequest struct {
-	LedgerID   string                 `json:"ledger_id"`
-	IdentityID string                 `json:"identity_id,omitempty"`
-	Currency   string                 `json:"currency"`
-	MetaData   map[string]interface{} `json:"meta_data,omitempty"`
+	LedgerID           string                 `json:"ledger_id"`
+	IdentityID         string                 `json:"identity_id,omitempty"`
+	Currency           string                 `json:"currency"`
+	TrackFundLineage   bool                   `json:"track_fund_lineage,omitempty"`
+	AllocationStrategy AllocationStrategy     `json:"allocation_strategy,omitempty"`
+	MetaData           map[string]interface{} `json:"meta_data,omitempty"`
 }
 
 func (s *LedgerBalanceService) Create(body CreateLedgerBalanceRequest) (*LedgerBalance, *http.Response, error) {
+	body.AllocationStrategy = normalizeAllocationStrategy(body.AllocationStrategy)
+	if err := ValidateCreateLedgerBalance(body); err != nil {
+		return nil, nil, err
+	}
+
 	req, err := s.client.NewRequest("balances", http.MethodPost, body)
 	if err != nil {
 		return nil, nil, err

--- a/ledger_balance_test.go
+++ b/ledger_balance_test.go
@@ -53,6 +53,66 @@ func TestLedgerBalanceService_Create_Success(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestLedgerBalanceService_Create_WithLineageFields(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+
+	body := blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:           "ledger123",
+		IdentityID:         "identity123",
+		Currency:           "USD",
+		TrackFundLineage:   true,
+		AllocationStrategy: blnkgo.AllocationStrategyPROPORTIONAL,
+	}
+
+	mockClient.On("NewRequest", "balances", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusCreated,
+	}, nil).Run(func(args mock.Arguments) {
+		ledgerBalance := args.Get(1).(*blnkgo.LedgerBalance)
+		ledgerBalance.BalanceID = "balance123"
+		ledgerBalance.TrackFundLineage = true
+		ledgerBalance.AllocationStrategy = blnkgo.AllocationStrategyPROPORTIONAL
+	})
+
+	ledgerBalance, resp, err := svc.Create(body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.True(t, ledgerBalance.TrackFundLineage)
+	assert.Equal(t, blnkgo.AllocationStrategyPROPORTIONAL, ledgerBalance.AllocationStrategy)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_Create_InvalidAllocationStrategy(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+
+	_, resp, err := svc.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:           "ledger123",
+		Currency:           "USD",
+		AllocationStrategy: blnkgo.AllocationStrategy("INVALID"),
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+}
+
+func TestLedgerBalanceService_Create_TrackFundLineageRequiresIdentity(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+
+	_, resp, err := svc.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:         "ledger123",
+		Currency:         "USD",
+		TrackFundLineage: true,
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+}
+
 func TestLedgerBalanceService_Create_EmptyRequest(t *testing.T) {
 	mockClient, svc := setupLedgerBalanceService()
 	body := blnkgo.CreateLedgerBalanceRequest{}

--- a/postman/README.md
+++ b/postman/README.md
@@ -22,6 +22,7 @@ Import these two files into Postman (one-time):
 | **Issue #70 — Refund skip_queue** | `POST /refund-transaction/{id}` | 0.14.5+ |
 | **Issue #71 — precise_distribution** | `POST /transactions` split legs | 0.14.5+ |
 | **Issue #86 — Update skip_queue** | `PUT /transactions/inflight/{id}` + bulk commit/void | 0.14.5+ |
+| **Issue #68 — Balance lineage create** | `POST /balances` with `track_fund_lineage` | 0.14.5+ |
 
 ## CLI (same tests, no Postman UI)
 

--- a/postman/go-sdk-local-core-tests.postman_collection.json
+++ b/postman/go-sdk-local-core-tests.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Blnk Go SDK — Local Core Tests",
-    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #86 — UpdateStatus skip_queue\n- Issue #71 — precise_distribution split legs\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
+    "description": "Click **Run** on this collection to verify Go SDK issues against local Blnk Core 0.14.5.\n\n**Setup:** import `go-sdk-local-core.postman_environment.json` and select it.\n\n**Folders:**\n- Issue #40 — Transaction.RecoverQueue\n- Issue #70 — Transaction.Refund skip_queue\n- Issue #86 — UpdateStatus skip_queue\n- Issue #68 — Balance lineage create\n- Issue #71 — precise_distribution split legs\n- Issue #73 — Search identities resource type\n- Issue #36 — Transaction.GetLineage\n\nVariables are chained automatically between requests (where needed).",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -427,6 +427,147 @@
             },
             "url": "{{blnk_base_url}}/transactions/inflight/{{issue86_void_txn_id}}",
             "description": "Go SDK: Transaction.Update(id, UpdateStatus{Status: void, SkipQueue: true})"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Issue #68 — Balance lineage create",
+      "item": [
+        {
+          "name": "1. Create ledger",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('issue68_ledger_id', json.ledger_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Go SDK Issue 68\"\n}"
+            },
+            "url": "{{blnk_base_url}}/ledgers"
+          }
+        },
+        {
+          "name": "2. Create identity (seed)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('issue68_email', `issue68-${Date.now()}@example.com`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('issue68_identity_id', json.identity_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identity_type\": \"individual\",\n  \"first_name\": \"GoSDK\",\n  \"last_name\": \"Lineage\",\n  \"email_address\": \"{{issue68_email}}\",\n  \"phone_number\": \"1234567890\",\n  \"category\": \"customer\",\n  \"street\": \"123 Main St\",\n  \"country\": \"USA\",\n  \"state\": \"CA\",\n  \"post_code\": \"90001\",\n  \"city\": \"Los Angeles\",\n  \"dob\": \"1990-01-15T00:00:00Z\",\n  \"gender\": \"Male\",\n  \"nationality\": \"American\"\n}"
+            },
+            "url": "{{blnk_base_url}}/identities"
+          }
+        },
+        {
+          "name": "3. Create balance with lineage",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 201', function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.expect(json.track_fund_lineage).to.eql(true);",
+                  "pm.expect(json.allocation_strategy).to.eql('PROPORTIONAL');",
+                  "pm.collectionVariables.set('issue68_balance_id', json.balance_id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ledger_id\": \"{{issue68_ledger_id}}\",\n  \"identity_id\": \"{{issue68_identity_id}}\",\n  \"currency\": \"USD\",\n  \"track_fund_lineage\": true,\n  \"allocation_strategy\": \"PROPORTIONAL\"\n}"
+            },
+            "url": "{{blnk_base_url}}/balances",
+            "description": "Go SDK: LedgerBalance.Create with TrackFundLineage + AllocationStrategy"
+          }
+        },
+        {
+          "name": "4. GET balance lineage fields",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('track_fund_lineage persisted', function () {",
+                  "    pm.expect(json.track_fund_lineage).to.eql(true);",
+                  "});",
+                  "pm.test('allocation_strategy persisted', function () {",
+                  "    pm.expect(json.allocation_strategy).to.eql('PROPORTIONAL');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Blnk-Key", "value": "{{blnk_api_key}}" }
+            ],
+            "url": "{{blnk_base_url}}/balances/{{issue68_balance_id}}"
           }
         }
       ]

--- a/validate_ledger_balance.go
+++ b/validate_ledger_balance.go
@@ -1,0 +1,41 @@
+package blnkgo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AllocationStrategy controls how tagged provider funds are spent when fund lineage is enabled.
+type AllocationStrategy string
+
+const (
+	AllocationStrategyFIFO         AllocationStrategy = "FIFO"
+	AllocationStrategyLIFO         AllocationStrategy = "LIFO"
+	AllocationStrategyPROPORTIONAL AllocationStrategy = "PROPORTIONAL"
+)
+
+func isValidAllocationStrategy(strategy AllocationStrategy) bool {
+	switch strategy {
+	case AllocationStrategyFIFO, AllocationStrategyLIFO, AllocationStrategyPROPORTIONAL:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidateCreateLedgerBalance(b CreateLedgerBalanceRequest) error {
+	if b.TrackFundLineage && b.IdentityID == "" {
+		return fmt.Errorf("identity_id is required when track_fund_lineage is enabled")
+	}
+	if b.AllocationStrategy != "" && !isValidAllocationStrategy(b.AllocationStrategy) {
+		return fmt.Errorf("allocation_strategy must be one of FIFO, LIFO, or PROPORTIONAL")
+	}
+	return nil
+}
+
+func normalizeAllocationStrategy(strategy AllocationStrategy) AllocationStrategy {
+	if strategy == "" {
+		return strategy
+	}
+	return AllocationStrategy(strings.ToUpper(string(strategy)))
+}

--- a/validate_ledger_balance_test.go
+++ b/validate_ledger_balance_test.go
@@ -1,0 +1,69 @@
+package blnkgo_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCreateLedgerBalance_AllocationStrategy(t *testing.T) {
+	require.NoError(t, blnkgo.ValidateCreateLedgerBalance(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:           "ldg_1",
+		Currency:           "USD",
+		IdentityID:         "idt_1",
+		TrackFundLineage:   true,
+		AllocationStrategy: blnkgo.AllocationStrategyPROPORTIONAL,
+	}))
+
+	err := blnkgo.ValidateCreateLedgerBalance(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:           "ldg_1",
+		Currency:           "USD",
+		AllocationStrategy: blnkgo.AllocationStrategy("INVALID"),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "allocation_strategy must be one of FIFO, LIFO, or PROPORTIONAL")
+}
+
+func TestValidateCreateLedgerBalance_TrackFundLineageRequiresIdentity(t *testing.T) {
+	err := blnkgo.ValidateCreateLedgerBalance(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:         "ldg_1",
+		Currency:         "USD",
+		TrackFundLineage: true,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "identity_id is required when track_fund_lineage is enabled")
+}
+
+func TestCreateLedgerBalanceRequest_JSONMarshal(t *testing.T) {
+	body := blnkgo.CreateLedgerBalanceRequest{
+		LedgerID:           "ldg_1",
+		IdentityID:         "idt_1",
+		Currency:           "USD",
+		TrackFundLineage:   true,
+		AllocationStrategy: blnkgo.AllocationStrategyLIFO,
+	}
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	require.Equal(t, true, decoded["track_fund_lineage"])
+	require.Equal(t, "LIFO", decoded["allocation_strategy"])
+}
+
+func TestLedgerBalance_UnmarshalJSON_LineageFields(t *testing.T) {
+	payload := []byte(`{
+		"balance_id": "bln_1",
+		"ledger_id": "ldg_1",
+		"currency": "USD",
+		"track_fund_lineage": true,
+		"allocation_strategy": "PROPORTIONAL"
+	}`)
+
+	var bal blnkgo.LedgerBalance
+	require.NoError(t, json.Unmarshal(payload, &bal))
+	require.True(t, bal.TrackFundLineage)
+	require.Equal(t, blnkgo.AllocationStrategyPROPORTIONAL, bal.AllocationStrategy)
+}


### PR DESCRIPTION
## Summary
- Adds `TrackFundLineage` and `AllocationStrategy` (`FIFO` | `LIFO` | `PROPORTIONAL`) to `CreateLedgerBalanceRequest` and response `LedgerBalance`
- Client validation mirrors Core: `identity_id` required when `track_fund_lineage` is true; invalid `allocation_strategy` rejected before request
- Unit tests for validation, JSON marshal/unmarshal, and request forwarding; integration tests for create + GET persistence
- Postman folder **Issue #68 — Balance lineage create** (4 requests); README example added

Closes #68

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -v ./integration/... -run Issue68` (local Core 0.14.5)
- [x] Newman folder **Issue #68** — 6/6 assertions pass