### PR TITLE
DX: implement retry strategy in CallWithRetry (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,26 @@ func main() {
 
 This creates a new ledger for storing customer balances.
 
+### Retries
+
+`WithRetry` sets the **total number of attempts** (first try included). Default is `1` (no retries).
+
+```go
+client := blnkgo.NewClient(
+    baseURL,
+    &apiKey,
+    blnkgo.WithRetry(3),                    // up to 3 attempts
+    blnkgo.WithRetryDelay(2 * time.Second), // linear backoff base delay
+)
+```
+
+Retry behavior (aligned with the TypeScript SDK):
+
+- **GET** requests retry on **5xx** responses and retryable network errors
+- **POST**, **PUT**, and **DELETE** are **not** retried (avoids duplicate money movement)
+- Request timeouts are not retried
+- Backoff delay is `RetryDelay × attempt` between retries (2s, 4s, … with default delay)
+
 ### Updating a Ledger Name
 
 Rename an existing ledger without changing its ID or affecting balances and transactions:

--- a/call_retry_close_test.go
+++ b/call_retry_close_test.go
@@ -1,0 +1,82 @@
+package blnkgo
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type trackCloseBody struct {
+	io.Reader
+	closed *bool
+}
+
+func (t *trackCloseBody) Close() error {
+	*t.closed = true
+	return nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestCallWithRetry_ClosesBodyOnSuccess(t *testing.T) {
+	closed := false
+	u := mustParseURL(t, "http://example.com/")
+	client := NewClient(u, nil)
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: &trackCloseBody{
+				Reader: strings.NewReader(`{"ledger_id":"ldg_1","name":"Test"}`),
+				closed: &closed,
+			},
+			Header: make(http.Header),
+		}, nil
+	})}
+
+	req, err := client.NewRequest("ledgers/ldg_1", http.MethodGet, nil)
+	require.NoError(t, err)
+
+	var ledger Ledger
+	_, err = client.CallWithRetry(req, &ledger)
+	require.NoError(t, err)
+	require.True(t, closed)
+}
+
+func TestCallWithRetry_ClosesBodyOnTerminalError(t *testing.T) {
+	closed := false
+	u := mustParseURL(t, "http://example.com/")
+	client := NewClient(u, nil)
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body: &trackCloseBody{
+				Reader: strings.NewReader(`{"message":"not found"}`),
+				closed: &closed,
+			},
+			Header: make(http.Header),
+		}, nil
+	})}
+
+	req, err := client.NewRequest("ledgers/missing", http.MethodGet, nil)
+	require.NoError(t, err)
+
+	var ledger Ledger
+	_, err = client.CallWithRetry(req, &ledger)
+	require.Error(t, err)
+	require.True(t, closed)
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}

--- a/client.go
+++ b/client.go
@@ -44,6 +44,7 @@ type service struct {
 
 type Options struct {
 	RetryCount int
+	RetryDelay time.Duration
 	Timeout    time.Duration
 	Logger     Logger
 }
@@ -51,6 +52,7 @@ type Options struct {
 func DefaultOptions() Options {
 	return Options{
 		RetryCount: 1,
+		RetryDelay: defaultRetryDelay,
 		Timeout:    time.Second * 10,
 		Logger:     NewDefaultLogger(),
 	}
@@ -126,19 +128,30 @@ func (c *Client) NewRequest(endpoint, method string, opt interface{}) (*http.Req
 		u.RawQuery = q.Encode()
 	}
 
-	var bodyBuf io.ReadWriter
-
+	var bodyBytes []byte
 	if method != http.MethodGet && opt != nil {
-		bodyBuf = new(bytes.Buffer)
-		err := json.NewEncoder(bodyBuf).Encode(opt)
+		var err error
+		bodyBytes, err = json.Marshal(opt)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	req, err := http.NewRequest(method, u.String(), bodyBuf)
+	var bodyReader io.Reader
+	if len(bodyBytes) > 0 {
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	req, err := http.NewRequest(method, u.String(), bodyReader)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(bodyBytes) > 0 {
+		req.ContentLength = int64(len(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
 	}
 
 	//if c has api key, add it to the header
@@ -150,39 +163,53 @@ func (c *Client) NewRequest(endpoint, method string, opt interface{}) (*http.Req
 	return req, nil
 }
 
-// to:Do implement retry strategies
 func (c *Client) CallWithRetry(req *http.Request, resBody interface{}) (*http.Response, error) {
-	retryCount := c.options.RetryCount
+	maxAttempts := normalizeRetryCount(c.options.RetryCount)
+	baseDelay := normalizeRetryDelay(c.options.RetryDelay)
+	canRetry := maxAttempts > 1 && isRetryableHTTPMethod(req.Method)
 
-	var resp *http.Response
-	var err error
+	var lastResp *http.Response
+	var lastErr error
 
-	for i := 0; i < retryCount; i++ {
-		resp, err = c.client.Do(req)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 && canRetry {
+			delay := retryDelayForAttempt(attempt-1, baseDelay)
+			c.options.Logger.Info(fmt.Sprintf("Retrying request (attempt %d/%d) after %v", attempt, maxAttempts, delay))
+			time.Sleep(delay)
+			if err := resetRequestBody(req); err != nil {
+				return lastResp, err
+			}
+		}
+
+		resp, err := c.client.Do(req)
 		if err != nil {
+			lastErr = err
 			c.options.Logger.Info(err.Error())
-			time.Sleep(time.Second * 2)
+			if canRetry && attempt < maxAttempts && isRetryableNetworkError(err) {
+				continue
+			}
+			return lastResp, err
+		}
+
+		if canRetry && isRetryableHTTPStatus(resp.StatusCode) && attempt < maxAttempts {
+			c.options.Logger.Error(fmt.Sprintf("Request failed with status %d; retrying.", resp.StatusCode))
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			lastResp = resp
 			continue
 		}
 
-		defer resp.Body.Close()
-		if resp.StatusCode >= 500 {
-			logString := fmt.Sprintf("Request failed with status code %v and Status %v", resp.StatusCode, resp.Status)
-			c.options.Logger.Error(logString)
-			time.Sleep(time.Second * 2)
-			continue
+		decodeErr := c.DecodeResponse(resp, resBody)
+		if decodeErr != nil {
+			return resp, decodeErr
 		}
-
-		//check resp
-		err = c.DecodeResponse(resp, resBody)
-		if err != nil {
-			c.options.Logger.Error(err.Error())
-			return resp, err
-		}
-
 		return resp, nil
 	}
-	return nil, errors.New("max retry count exceeded")
+
+	if lastErr != nil {
+		return lastResp, lastErr
+	}
+	return lastResp, errors.New("request failed after maximum retry attempts")
 }
 
 // decode response, this function will take in a response, and an interface it'll then decode the response body into the interface

--- a/client.go
+++ b/client.go
@@ -200,6 +200,7 @@ func (c *Client) CallWithRetry(req *http.Request, resBody interface{}) (*http.Re
 		}
 
 		decodeErr := c.DecodeResponse(resp, resBody)
+		resp.Body.Close()
 		if decodeErr != nil {
 			return resp, decodeErr
 		}

--- a/client_options.go
+++ b/client_options.go
@@ -16,6 +16,12 @@ func WithRetry(count int) ClientOption {
 	}
 }
 
+func WithRetryDelay(delay time.Duration) ClientOption {
+	return func(c *Client) {
+		c.options.RetryDelay = delay
+	}
+}
+
 func WithTimeout(timeout time.Duration) ClientOption {
 	return func(c *Client) {
 		c.options.Timeout = timeout

--- a/client_retry_test.go
+++ b/client_retry_test.go
@@ -1,0 +1,109 @@
+package blnkgo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+type retryLedgerResponse struct {
+	LedgerID string `json:"ledger_id"`
+	Name     string `json:"name"`
+}
+
+func newRetryTestClient(t *testing.T, serverURL string, opts ...blnkgo.ClientOption) *blnkgo.Client {
+	t.Helper()
+	u, err := url.Parse(serverURL + "/")
+	require.NoError(t, err)
+	opts = append([]blnkgo.ClientOption{
+		blnkgo.WithRetry(3),
+		blnkgo.WithRetryDelay(5 * time.Millisecond),
+	}, opts...)
+	return blnkgo.NewClient(u, nil, opts...)
+}
+
+func TestCallWithRetry_RetriesGETOn5xx(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		if attempts.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(retryLedgerResponse{LedgerID: "ldg_1", Name: "Retry OK"})
+	}))
+	defer server.Close()
+
+	client := newRetryTestClient(t, server.URL)
+	ledger, resp, err := client.Ledger.Get("ldg_1")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "ldg_1", ledger.LedgerID)
+	require.Equal(t, int32(3), attempts.Load())
+}
+
+func TestCallWithRetry_DoesNotRetryPOSTOn5xx(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"server error"}`))
+	}))
+	defer server.Close()
+
+	client := newRetryTestClient(t, server.URL)
+	_, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "No Retry"})
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestCallWithRetry_DoesNotRetryGETOn4xx(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	}))
+	defer server.Close()
+
+	client := newRetryTestClient(t, server.URL)
+	_, resp, err := client.Ledger.Get("missing")
+	require.Error(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestNewRequest_SetsReplayableBody(t *testing.T) {
+	u, err := url.Parse("http://localhost:5001/")
+	require.NoError(t, err)
+	client := blnkgo.NewClient(u, nil)
+
+	req, err := client.NewRequest("ledgers", http.MethodPost, blnkgo.CreateLedgerRequest{Name: "Replay"})
+	require.NoError(t, err)
+	require.NotNil(t, req.GetBody)
+
+	first, err := req.GetBody()
+	require.NoError(t, err)
+	defer first.Close()
+	var payload1 map[string]string
+	require.NoError(t, json.NewDecoder(first).Decode(&payload1))
+
+	second, err := req.GetBody()
+	require.NoError(t, err)
+	defer second.Close()
+	var payload2 map[string]string
+	require.NoError(t, json.NewDecoder(second).Decode(&payload2))
+
+	require.Equal(t, payload1, payload2)
+	require.Equal(t, "Replay", payload1["name"])
+}

--- a/request_retry.go
+++ b/request_retry.go
@@ -1,0 +1,65 @@
+package blnkgo
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+const defaultRetryDelay = 2 * time.Second
+
+func normalizeRetryCount(count int) int {
+	if count < 1 {
+		return 1
+	}
+	return count
+}
+
+func normalizeRetryDelay(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return defaultRetryDelay
+	}
+	return delay
+}
+
+func isRetryableHTTPMethod(method string) bool {
+	return method == http.MethodGet
+}
+
+func isRetryableHTTPStatus(statusCode int) bool {
+	return statusCode >= http.StatusInternalServerError
+}
+
+func retryDelayForAttempt(attempt int, baseDelay time.Duration) time.Duration {
+	if attempt < 1 {
+		return baseDelay
+	}
+	return baseDelay * time.Duration(attempt)
+}
+
+func resetRequestBody(req *http.Request) error {
+	if req.GetBody == nil {
+		return nil
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return err
+	}
+	req.Body = body
+	return nil
+}
+
+func isRetryableNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Timeouts are not retried to avoid duplicate mutating calls when the server may have processed the request.
+	if errors.Is(err, http.ErrHandlerTimeout) {
+		return false
+	}
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	return true
+}

--- a/request_retry_test.go
+++ b/request_retry_test.go
@@ -1,0 +1,37 @@
+package blnkgo
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeRetryCount(t *testing.T) {
+	require.Equal(t, 1, normalizeRetryCount(0))
+	require.Equal(t, 1, normalizeRetryCount(-1))
+	require.Equal(t, 3, normalizeRetryCount(3))
+}
+
+func TestNormalizeRetryDelay(t *testing.T) {
+	require.Equal(t, defaultRetryDelay, normalizeRetryDelay(0))
+	require.Equal(t, 500*time.Millisecond, normalizeRetryDelay(500*time.Millisecond))
+}
+
+func TestRetryDelayForAttempt(t *testing.T) {
+	require.Equal(t, 2*time.Second, retryDelayForAttempt(1, 2*time.Second))
+	require.Equal(t, 4*time.Second, retryDelayForAttempt(2, 2*time.Second))
+}
+
+func TestIsRetryableHTTPMethod(t *testing.T) {
+	require.True(t, isRetryableHTTPMethod(http.MethodGet))
+	require.False(t, isRetryableHTTPMethod(http.MethodPost))
+	require.False(t, isRetryableHTTPMethod(http.MethodPut))
+}
+
+func TestIsRetryableHTTPStatus(t *testing.T) {
+	require.False(t, isRetryableHTTPStatus(http.StatusBadRequest))
+	require.True(t, isRetryableHTTPStatus(http.StatusInternalServerError))
+	require.True(t, isRetryableHTTPStatus(http.StatusBadGateway))
+}


### PR DESCRIPTION
## Summary
- Implement retry logic in `CallWithRetry` with linear backoff (`WithRetryDelay`, default 2s)
- **GET** retries on 5xx and retryable network errors; **POST/PUT/DELETE** are not retried (matches blnk-ts)
- Fix request body replay via `GetBody` for safe retries
- Remove stale `// to:Do implement retry strategies` comment
- Document retry behavior in README

## Test plan
- [x] `go test ./...`
- [x] `client_retry_test.go` — GET 5xx retry, POST no retry, 4xx no retry, replayable body

Closes #76