### PR TITLE
Add Identity.Filter (POST identities/filter) (#55)

### DIFF
--- a/.cursor/rules/blnk-sdk-workflow.mdc
+++ b/.cursor/rules/blnk-sdk-workflow.mdc
@@ -1,25 +1,29 @@
 ---
-description: Blnk Go SDK workflow — no Postman in git, integration tests only
+description: Blnk Go SDK workflow — Postman cloud sync, run tests, no Postman in git
 alwaysApply: true
 ---
 
 # Blnk Go SDK workflow
 
-## Postman — never commit
+## Postman cloud — always sync automatically
 
-- Postman collections are for **local personal testing only**
-- **Do NOT** add, update, or commit `postman/` in blnk-go PRs
-- **Do NOT** use Postman MCP to sync collections into the repo
-- **Do NOT** add Postman folders to PR descriptions unless the user explicitly asks
-- Keep local Postman files in `manual/postman/` (gitignored)
-- Verify against Core with: `go test -tags=integration -run IssueXX ./integration/...`
+- After implementing an issue, **always** push the Postman folder to the user's **Postman cloud** via Postman MCP
+- Collection: **Blnk Go SDK — Local Core Tests** (`51542189-ceaf8a9a-751e-44bf-95a4-0dc7ce2cf28e`)
+- **Do NOT** tell the user to import JSON manually — sync it for them
+- **Do NOT** commit `postman/` or `manual/` to git
+
+## Testing — agent runs tests, user gets snippets
+
+- Always run `go test ./...` before finishing
+- Run `go test -tags=integration -run IssueXX ./integration/...` when Core integration applies
+- Give the user a **copy-paste Go snippet** to try the feature locally (not “run tests yourself” without code)
 
 ## PR scope (blnk-go)
 
-- SDK code + unit tests (`*_test.go` at package root)
-- Integration tests (`integration/issueXX_test.go`)
-- README SDK usage examples only
-- No Postman, no `manual/` artifacts
+- SDK code + unit tests (`*_test.go`)
+- Integration tests (`integration/issueXX_test.go`) when endpoint hits Core
+- README usage example for the new method
+- No Postman files in git
 
 ## Git
 

--- a/.cursor/rules/blnk-sdk-workflow.mdc
+++ b/.cursor/rules/blnk-sdk-workflow.mdc
@@ -1,29 +1,25 @@
 ---
-description: Blnk Go SDK workflow — Postman cloud sync, run tests, no Postman in git
+description: Blnk Go SDK workflow — no Postman in git, integration tests only
 alwaysApply: true
 ---
 
 # Blnk Go SDK workflow
 
-## Postman cloud — always sync automatically
+## Postman — never commit
 
-- After implementing an issue, **always** push the Postman folder to the user's **Postman cloud** via Postman MCP
-- Collection: **Blnk Go SDK — Local Core Tests** (`51542189-ceaf8a9a-751e-44bf-95a4-0dc7ce2cf28e`)
-- **Do NOT** tell the user to import JSON manually — sync it for them
-- **Do NOT** commit `postman/` or `manual/` to git
-
-## Testing — agent runs tests, user gets snippets
-
-- Always run `go test ./...` before finishing
-- Run `go test -tags=integration -run IssueXX ./integration/...` when Core integration applies
-- Give the user a **copy-paste Go snippet** to try the feature locally (not “run tests yourself” without code)
+- Postman collections are for **local personal testing only**
+- **Do NOT** add, update, or commit `postman/` in blnk-go PRs
+- **Do NOT** use Postman MCP to sync collections into the repo
+- **Do NOT** add Postman folders to PR descriptions unless the user explicitly asks
+- Keep local Postman files in `manual/postman/` (gitignored)
+- Verify against Core with: `go test -tags=integration -run IssueXX ./integration/...`
 
 ## PR scope (blnk-go)
 
-- SDK code + unit tests (`*_test.go`)
-- Integration tests (`integration/issueXX_test.go`) when endpoint hits Core
-- README usage example for the new method
-- No Postman files in git
+- SDK code + unit tests (`*_test.go` at package root)
+- Integration tests (`integration/issueXX_test.go`)
+- README SDK usage examples only
+- No Postman, no `manual/` artifacts
 
 ## Git
 

--- a/README.md
+++ b/README.md
@@ -659,6 +659,30 @@ identity, resp, err := client.Identity.Create(identityBody)
 
 Only `identity_type` (when set) and `identity_id` format are validated client-side; other fields are optional per the API reference.
 
+Filter identities with structured query filters:
+
+```go
+result, resp, err := client.Identity.Filter(blnkgo.FilterParams{
+    Filters: []blnkgo.Filter{
+        {Field: "email_address", Operator: blnkgo.OpEqual, Value: "john.doe@example.com"},
+        {Field: "category", Operator: blnkgo.OpEqual, Value: "customer"},
+    },
+    Limit:        20,
+    Offset:       0,
+    IncludeCount: true,
+})
+if err != nil {
+    fmt.Printf("Error filtering identities: %v\n", err)
+    return
+}
+
+fmt.Printf("Filter status: %d\n", resp.StatusCode)
+if result.TotalCount != nil {
+    fmt.Printf("Total matches: %d\n", *result.TotalCount)
+}
+fmt.Printf("Data: %+v\n", result.Data)
+```
+
 ### Reconciliation
 
 The reconciliation feature allows you to match and verify transactions against external data sources.

--- a/identity.go
+++ b/identity.go
@@ -93,6 +93,21 @@ func (s *IdentityService) Update(identityId string, identity *Identity) (*Identi
 	return identityResponse, resp, nil
 }
 
+func (s *IdentityService) Filter(params FilterParams) (*FilterResponse, *http.Response, error) {
+	req, err := s.client.NewRequest("identities/filter", http.MethodPost, params)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var filterResponse FilterResponse
+	resp, err := s.client.CallWithRetry(req, &filterResponse)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &filterResponse, resp, nil
+}
+
 func NewIdentityService(client ClientInterface) *IdentityService {
 	return &IdentityService{client: client}
 }

--- a/identity_test.go
+++ b/identity_test.go
@@ -367,3 +367,120 @@ func TestIdentityService_Create_InvalidIdentityType(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.Nil(t, httpResp)
 }
+
+func TestIdentityService_Filter_Success(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	body := blnkgo.FilterParams{
+		Filters: []blnkgo.Filter{
+			{Field: "email_address", Operator: blnkgo.OpEqual, Value: "john@example.com"},
+		},
+		Limit: 10,
+	}
+
+	expectedResponse := &blnkgo.FilterResponse{
+		Data: []blnkgo.IdentityResponse{
+			{
+				IdentityId: "idt_1",
+				Identity: blnkgo.Identity{
+					IdentityType: blnkgo.Individual,
+					FirstName:  "John",
+					LastName:   "Doe",
+					EmailAddress: "john@example.com",
+					Category:   "customer",
+				},
+			},
+		},
+	}
+
+	mockClient.On("NewRequest", "identities/filter", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		result := args.Get(1).(*blnkgo.FilterResponse)
+		*result = *expectedResponse
+	})
+
+	result, resp, err := svc.Filter(body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_Filter_WithIncludeCount(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	body := blnkgo.FilterParams{
+		Filters: []blnkgo.Filter{
+			{Field: "category", Operator: blnkgo.OpEqual, Value: "customer"},
+		},
+		IncludeCount: true,
+	}
+
+	count := int64(1)
+	expectedResponse := &blnkgo.FilterResponse{
+		Data: []blnkgo.IdentityResponse{
+			{IdentityId: "idt_1"},
+		},
+		TotalCount: &count,
+	}
+
+	mockClient.On("NewRequest", "identities/filter", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		result := args.Get(1).(*blnkgo.FilterResponse)
+		*result = *expectedResponse
+	})
+
+	result, resp, err := svc.Filter(body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result.TotalCount)
+	assert.Equal(t, int64(1), *result.TotalCount)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_Filter_NewRequestError(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	body := blnkgo.FilterParams{
+		Filters: []blnkgo.Filter{
+			{Field: "first_name", Operator: blnkgo.OpEqual, Value: "Jane"},
+		},
+	}
+
+	mockClient.On("NewRequest", "identities/filter", http.MethodPost, body).Return(nil, fmt.Errorf("request error"))
+
+	result, resp, err := svc.Filter(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_Filter_ServerError(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	body := blnkgo.FilterParams{
+		Filters: []blnkgo.Filter{
+			{Field: "first_name", Operator: blnkgo.OpEqual, Value: "Jane"},
+		},
+	}
+
+	expectedResp := &http.Response{StatusCode: http.StatusInternalServerError}
+	mockClient.On("NewRequest", "identities/filter", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(expectedResp, fmt.Errorf("server error"))
+
+	result, resp, err := svc.Filter(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -20,6 +20,7 @@ go test -tags=integration -v ./integration/... -run Issue71
 go test -tags=integration -v ./integration/... -run Issue40
 go test -tags=integration -v ./integration/... -run Issue73
 go test -tags=integration -v ./integration/... -run Issue72
+go test -tags=integration -v ./integration/... -run Issue55
 go test -tags=integration -v ./integration/... -run Issue36
 
 # all integration tests
@@ -45,6 +46,7 @@ go test -tags=integration -v ./integration/...
 | #68 balance lineage create | 0.14.x+ | track_fund_lineage + allocation_strategy on POST /balances |
 | #73 search identities | 0.14.x+ | Not 0.15-only |
 | #72 identity optional id | 0.14.x+ | Caller-supplied identity_id on POST /identities |
+| #55 identity filter | 0.14.x+ | POST /identities/filter |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |
 

--- a/integration/issue55_test.go
+++ b/integration/issue55_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+// Integration tests for issue #55 — Identity.Filter (POST /identities/filter).
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue55
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func identitiesFromFilter(t *testing.T, result *blnkgo.FilterResponse) []blnkgo.IdentityResponse {
+	t.Helper()
+	raw, err := json.Marshal(result.Data)
+	require.NoError(t, err)
+	var identities []blnkgo.IdentityResponse
+	require.NoError(t, json.Unmarshal(raw, &identities))
+	return identities
+}
+
+func TestIssue55_FilterIdentities_ByEmail(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	email := fmt.Sprintf("issue55-filter-%s@example.com", suffix)
+
+	created, resp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Filter",
+		LastName:     "Test",
+		EmailAddress: email,
+		Category:     "customer",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	result, resp, err := client.Identity.Filter(blnkgo.FilterParams{
+		Filters: []blnkgo.Filter{
+			{Field: "email_address", Operator: blnkgo.OpEqual, Value: email},
+		},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	identities := identitiesFromFilter(t, result)
+	require.NotEmpty(t, identities)
+	require.Equal(t, created.IdentityId, identities[0].IdentityId)
+	require.Equal(t, email, identities[0].EmailAddress)
+}
+
+func TestIssue55_FilterIdentities_IncludeCount(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	email := fmt.Sprintf("issue55-count-%s@example.com", suffix)
+
+	_, resp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Count",
+		EmailAddress: email,
+		Category:     "customer",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	result, resp, err := client.Identity.Filter(blnkgo.FilterParams{
+		Filters: []blnkgo.Filter{
+			{Field: "email_address", Operator: blnkgo.OpEqual, Value: email},
+		},
+		IncludeCount: true,
+		Limit:        10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, result.TotalCount)
+	require.GreaterOrEqual(t, *result.TotalCount, int64(1))
+}


### PR DESCRIPTION
## Summary
- Add `Identity.Filter` calling `POST /identities/filter` using shared `FilterParams` / `FilterResponse`
- Unit tests (mocked HTTP) and integration tests against Core 0.14.5
- README usage example

## Acceptance criteria (#55)
- [x] `Identity.Filter` → `identities/filter`
- [x] Reuses shared `FilterParams` / `FilterResponse` (same as Ledger, Balance, Transaction filters)
- [x] No extra client validation (matches other Filter methods)
- [x] Unit tests with mocked HTTP
- [x] README example

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue55 ./integration/...`

Closes #55