### PR TITLE
Add Reconciliation.Get (GET /reconciliation/{reconciliation_id}) (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,20 @@ instantResp, resp, err := client.Reconciliation.RunInstant(blnkgo.RunInstantReco
 // instantResp.ReconciliationID — poll GET /reconciliation/{id} for status
 ```
 
+#### Get Reconciliation
+
+Poll reconciliation status and match counts after starting a run.
+
+```go
+recon, resp, err := client.Reconciliation.Get(instantResp.ReconciliationID)
+if err != nil {
+    panic(err)
+}
+fmt.Println("Status:", recon.Status)
+fmt.Println("Matched:", recon.MatchedTransactions)
+fmt.Println("Unmatched:", recon.UnmatchedTransactions)
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/integration/README.md
+++ b/integration/README.md
@@ -22,6 +22,7 @@ go test -tags=integration -v ./integration/... -run Issue73
 go test -tags=integration -v ./integration/... -run Issue72
 go test -tags=integration -v ./integration/... -run Issue55
 go test -tags=integration -v ./integration/... -run Issue41
+go test -tags=integration -v ./integration/... -run Issue42
 go test -tags=integration -v ./integration/... -run Issue36
 
 # all integration tests
@@ -49,6 +50,7 @@ go test -tags=integration -v ./integration/...
 | #72 identity optional id | 0.14.x+ | Caller-supplied identity_id on POST /identities |
 | #55 identity filter | 0.14.x+ | POST /identities/filter |
 | #41 instant reconciliation | 0.14.x+ | POST /reconciliation/start-instant |
+| #42 get reconciliation | 0.14.x+ | GET /reconciliation/{reconciliation_id} |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |
 

--- a/integration/issue42_test.go
+++ b/integration/issue42_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+// Integration tests for issue #42 — Reconciliation.Get (GET /reconciliation/{reconciliation_id}).
+// Requires Blnk Core running at http://localhost:5001 (docker compose up in blnk/).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue42
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue42_Get_AfterRunInstant(t *testing.T) {
+	client := newIntegrationClient(t)
+	ruleID := createInstantReconMatchingRule(t, client)
+
+	extID := fmt.Sprintf("ext-get-%d", time.Now().UnixNano())
+	started, resp, err := client.Reconciliation.RunInstant(blnkgo.RunInstantReconData{
+		ExternalTransactions: []blnkgo.ExternalTransaction{
+			{ID: extID, Amount: 1, Reference: "r1", Currency: "USD"},
+		},
+		Strategy:        blnkgo.ReconciliationStrategyOneToOne,
+		DryRun:          true,
+		MatchingRuleIDs: []string{ruleID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, started.ReconciliationID)
+
+	recon, resp, err := client.Reconciliation.Get(started.ReconciliationID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, started.ReconciliationID, recon.ReconciliationID)
+	require.NotEmpty(t, recon.Status)
+	require.NotEmpty(t, recon.UploadID)
+	require.False(t, recon.StartedAt.IsZero())
+}
+
+func TestIssue42_Get_EmptyID(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Reconciliation.Get("")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "reconciliation id is required")
+}
+
+func TestIssue42_Get_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Reconciliation.Get("recon_nonexistent_issue42")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/reconciliation.go
+++ b/reconciliation.go
@@ -1,6 +1,7 @@
 package blnkgo
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -69,6 +70,18 @@ type RunInstantReconResp struct {
 	ReconciliationID string `json:"reconciliation_id"`
 }
 
+// Reconciliation is the status and counts for a reconciliation run.
+type Reconciliation struct {
+	ReconciliationID      string     `json:"reconciliation_id"`
+	UploadID              string     `json:"upload_id"`
+	Status                string     `json:"status"`
+	MatchedTransactions   int        `json:"matched_transactions"`
+	UnmatchedTransactions int        `json:"unmatched_transactions"`
+	IsDryRun              bool       `json:"is_dry_run"`
+	StartedAt             time.Time  `json:"started_at"`
+	CompletedAt           *time.Time `json:"completed_at"`
+}
+
 const MaxInstantReconciliationItems = 10000
 
 func (s *ReconciliationService) CreateMatchingRule(matcher Matcher) (*RunReconResp, *http.Response, error) {
@@ -103,6 +116,25 @@ func (s *ReconciliationService) RunInstant(data RunInstantReconData) (*RunInstan
 	}
 
 	return reconResp, resp, nil
+}
+
+func (s *ReconciliationService) Get(reconciliationID string) (*Reconciliation, *http.Response, error) {
+	if reconciliationID == "" {
+		return nil, nil, fmt.Errorf("reconciliation id is required")
+	}
+
+	req, err := s.client.NewRequest(fmt.Sprintf("reconciliation/%s", reconciliationID), http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	recon := new(Reconciliation)
+	resp, err := s.client.CallWithRetry(req, recon)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return recon, resp, nil
 }
 
 func (s *ReconciliationService) Run(data RunReconData) (*RunReconResp, *http.Response, error) {

--- a/reconciliation_test.go
+++ b/reconciliation_test.go
@@ -3,6 +3,7 @@ package blnkgo_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -391,4 +392,77 @@ func TestRunInstantReconData_MinimalJSONOmitsOptionalFields(t *testing.T) {
 	assert.Contains(t, encoded, `"amount":1`)
 	assert.Contains(t, encoded, `"reference":"r1"`)
 	assert.Contains(t, encoded, `"currency":"USD"`)
+}
+
+func TestReconciliationService_Get_Success(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	reconID := "recon_abc123"
+	startedAt := time.Date(2025, 3, 15, 17, 43, 26, 0, time.UTC)
+	expected := &blnkgo.Reconciliation{
+		ReconciliationID:      reconID,
+		UploadID:              "instant_xyz",
+		Status:                "completed",
+		MatchedTransactions:   3,
+		UnmatchedTransactions: 0,
+		IsDryRun:              true,
+		StartedAt:             startedAt,
+	}
+
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/%s", reconID), http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		recon := args.Get(1).(*blnkgo.Reconciliation)
+		*recon = *expected
+	})
+
+	recon, httpResp, err := svc.Get(reconID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, expected, recon)
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_Get_EmptyID(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	recon, httpResp, err := svc.Get("")
+
+	assert.Error(t, err)
+	assert.Nil(t, recon)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "reconciliation id is required")
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_Get_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	reconID := "recon_abc123"
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/%s", reconID), http.MethodGet, nil).Return(nil, errors.New("failed to create request"))
+
+	recon, httpResp, err := svc.Get(reconID)
+
+	assert.Error(t, err)
+	assert.Nil(t, recon)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "failed to create request")
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_Get_NotFound(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	reconID := "recon_missing"
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/%s", reconID), http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusNotFound}, errors.New("not found"))
+
+	recon, httpResp, err := svc.Get(reconID)
+
+	assert.Error(t, err)
+	assert.Nil(t, recon)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusNotFound, httpResp.StatusCode)
+	mockClient.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary
- Add `Reconciliation.Get` calling `GET /reconciliation/{reconciliation_id}`
- Add `Reconciliation` response type matching Core/reference fields
- Client-side check: empty reconciliation id rejected before HTTP call
- Unit tests (mocked HTTP) and integration tests against Core 0.14.x

## Acceptance criteria (#42)
- [x] `Reconciliation.Get` → `/reconciliation/{reconciliation_id}`
- [x] Request/response Go types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] README usage example

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue42 ./integration/...`

Closes #42