### PR TITLE
Add Reconciliation.UpdateMatchingRule (PUT /reconciliation/matching-rules/{rule_id}) (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,21 @@ matcherBody := blnkgo.Matcher{
 matchingRule, resp, err := client.Reconciliation.CreateMatchingRule(matcherBody)
 ```
 
+#### Update Matching Rule
+
+```go
+updatedRule, resp, err := client.Reconciliation.UpdateMatchingRule(matchingRule.RuleID, blnkgo.Matcher{
+    Name:        "Updated Amount Match",
+    Description: "Updated match by amount only",
+    Criteria: []blnkgo.Criteria{
+        {
+            Field:    blnkgo.CriteriaFieldAmount,
+            Operator: blnkgo.ReconciliationOperatorEquals,
+        },
+    },
+})
+```
+
 #### Run Reconciliation
 
 ```go

--- a/integration/README.md
+++ b/integration/README.md
@@ -23,6 +23,7 @@ go test -tags=integration -v ./integration/... -run Issue72
 go test -tags=integration -v ./integration/... -run Issue55
 go test -tags=integration -v ./integration/... -run Issue41
 go test -tags=integration -v ./integration/... -run Issue42
+go test -tags=integration -v ./integration/... -run Issue43
 go test -tags=integration -v ./integration/... -run Issue36
 
 # all integration tests
@@ -51,6 +52,7 @@ go test -tags=integration -v ./integration/...
 | #55 identity filter | 0.14.x+ | POST /identities/filter |
 | #41 instant reconciliation | 0.14.x+ | POST /reconciliation/start-instant |
 | #42 get reconciliation | 0.14.x+ | GET /reconciliation/{reconciliation_id} |
+| #43 update matching rule | 0.14.x+ | PUT /reconciliation/matching-rules/{rule_id} |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |
 

--- a/integration/issue43_test.go
+++ b/integration/issue43_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+// Integration tests for issue #43 — Reconciliation.UpdateMatchingRule (PUT /reconciliation/matching-rules/{rule_id}).
+// Requires Blnk Core running at http://localhost:5001 (docker compose up in blnk/).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue43
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue43_UpdateMatchingRule(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	created, resp, err := client.Reconciliation.CreateMatchingRule(blnkgo.Matcher{
+		Name:        fmt.Sprintf("Issue43 rule %d", time.Now().UnixNano()),
+		Description: "Original description",
+		Criteria: []blnkgo.Criteria{
+			{
+				Field:    blnkgo.CriteriaFieldAmount,
+				Operator: blnkgo.ReconciliationOperatorEquals,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, created.RuleID)
+
+	updatedName := fmt.Sprintf("Issue43 updated %d", time.Now().UnixNano())
+	updated, resp, err := client.Reconciliation.UpdateMatchingRule(created.RuleID, blnkgo.Matcher{
+		Name:        updatedName,
+		Description: "Updated description",
+		Criteria: []blnkgo.Criteria{
+			{
+				Field:    blnkgo.CriteriaFieldReference,
+				Operator: blnkgo.ReconciliationOperatorEquals,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, created.RuleID, updated.RuleID)
+	require.Equal(t, updatedName, updated.Name)
+	require.Equal(t, "Updated description", updated.Description)
+	require.Len(t, updated.Criteria, 1)
+	require.Equal(t, blnkgo.CriteriaFieldReference, updated.Criteria[0].Field)
+}
+
+func TestIssue43_UpdateMatchingRule_EmptyID(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Reconciliation.UpdateMatchingRule("", blnkgo.Matcher{Name: "x"})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "matching rule id is required")
+}
+
+func TestIssue43_UpdateMatchingRule_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Reconciliation.UpdateMatchingRule("rule_nonexistent_issue43", blnkgo.Matcher{
+		Name: "Updated",
+		Criteria: []blnkgo.Criteria{
+			{Field: blnkgo.CriteriaFieldAmount, Operator: blnkgo.ReconciliationOperatorEquals},
+		},
+	})
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}

--- a/reconciliation.go
+++ b/reconciliation.go
@@ -99,6 +99,25 @@ func (s *ReconciliationService) CreateMatchingRule(matcher Matcher) (*RunReconRe
 	return reconResp, resp, nil
 }
 
+func (s *ReconciliationService) UpdateMatchingRule(ruleID string, matcher Matcher) (*RunReconResp, *http.Response, error) {
+	if ruleID == "" {
+		return nil, nil, fmt.Errorf("matching rule id is required")
+	}
+
+	req, err := s.client.NewRequest(fmt.Sprintf("reconciliation/matching-rules/%s", ruleID), http.MethodPut, matcher)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	reconResp := new(RunReconResp)
+	resp, err := s.client.CallWithRetry(req, reconResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return reconResp, resp, nil
+}
+
 func (s *ReconciliationService) RunInstant(data RunInstantReconData) (*RunInstantReconResp, *http.Response, error) {
 	if err := ValidateRunInstantReconData(data); err != nil {
 		return nil, nil, err

--- a/reconciliation_test.go
+++ b/reconciliation_test.go
@@ -466,3 +466,86 @@ func TestReconciliationService_Get_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, httpResp.StatusCode)
 	mockClient.AssertExpectations(t)
 }
+
+func TestReconciliationService_UpdateMatchingRule_Success(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	ruleID := "rule_abc123"
+	matcher := blnkgo.Matcher{
+		Name:        "Updated Rule",
+		Description: "Updated description",
+		Criteria: []blnkgo.Criteria{
+			{
+				Field:    blnkgo.CriteriaFieldAmount,
+				Operator: blnkgo.ReconciliationOperatorEquals,
+			},
+		},
+	}
+	expected := &blnkgo.RunReconResp{
+		Matcher:   matcher,
+		RuleID:    ruleID,
+		CreatedAt: time.Now().Format(time.RFC3339),
+		UpdatedAt: time.Now().Format(time.RFC3339),
+	}
+
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/matching-rules/%s", ruleID), http.MethodPut, matcher).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.RunReconResp)
+		*resp = *expected
+	})
+
+	result, httpResp, err := svc.UpdateMatchingRule(ruleID, matcher)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, expected, result)
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_UpdateMatchingRule_EmptyID(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	result, httpResp, err := svc.UpdateMatchingRule("", blnkgo.Matcher{Name: "x"})
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "matching rule id is required")
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_UpdateMatchingRule_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	ruleID := "rule_abc123"
+	matcher := blnkgo.Matcher{Name: "Updated Rule"}
+
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/matching-rules/%s", ruleID), http.MethodPut, matcher).Return(nil, errors.New("failed to create request"))
+
+	result, httpResp, err := svc.UpdateMatchingRule(ruleID, matcher)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "failed to create request")
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_UpdateMatchingRule_NotFound(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	ruleID := "rule_missing"
+	matcher := blnkgo.Matcher{Name: "Updated Rule"}
+
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/matching-rules/%s", ruleID), http.MethodPut, matcher).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusNotFound}, errors.New("not found"))
+
+	result, httpResp, err := svc.UpdateMatchingRule(ruleID, matcher)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusNotFound, httpResp.StatusCode)
+	mockClient.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- Add `Reconciliation.UpdateMatchingRule` calling `PUT /reconciliation/matching-rules/{rule_id}`
- Reuses existing `Matcher` request and `RunReconResp` response types
- Client-side check: empty rule id rejected before HTTP call
- Unit tests (mocked HTTP) and integration tests against Core 0.14.x

## Acceptance criteria (#43)
- [x] `Reconciliation.UpdateMatchingRule` → `/reconciliation/matching-rules/{rule_id}`
- [x] Request/response Go types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] README usage example

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue43 ./integration/...`

Closes #43