### PR TITLE
Add Reconciliation.DeleteMatchingRule (DELETE /reconciliation/matching-rules/{rule_id}) (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,16 @@ updatedRule, resp, err := client.Reconciliation.UpdateMatchingRule(matchingRule.
 })
 ```
 
+#### Delete Matching Rule
+
+```go
+deleted, resp, err := client.Reconciliation.DeleteMatchingRule(matchingRule.RuleID)
+if err != nil {
+    panic(err)
+}
+fmt.Println(deleted.Message)
+```
+
 #### Run Reconciliation
 
 ```go

--- a/integration/README.md
+++ b/integration/README.md
@@ -24,6 +24,7 @@ go test -tags=integration -v ./integration/... -run Issue55
 go test -tags=integration -v ./integration/... -run Issue41
 go test -tags=integration -v ./integration/... -run Issue42
 go test -tags=integration -v ./integration/... -run Issue43
+go test -tags=integration -v ./integration/... -run Issue44
 go test -tags=integration -v ./integration/... -run Issue36
 
 # all integration tests
@@ -53,6 +54,7 @@ go test -tags=integration -v ./integration/...
 | #41 instant reconciliation | 0.14.x+ | POST /reconciliation/start-instant |
 | #42 get reconciliation | 0.14.x+ | GET /reconciliation/{reconciliation_id} |
 | #43 update matching rule | 0.14.x+ | PUT /reconciliation/matching-rules/{rule_id} |
+| #44 delete matching rule | 0.14.x+ | DELETE /reconciliation/matching-rules/{rule_id} |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |
 

--- a/integration/issue44_test.go
+++ b/integration/issue44_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+// Integration tests for issue #44 — Reconciliation.DeleteMatchingRule (DELETE /reconciliation/matching-rules/{rule_id}).
+// Requires Blnk Core running at http://localhost:5001 (docker compose up in blnk/).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue44
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue44_DeleteMatchingRule(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	created, resp, err := client.Reconciliation.CreateMatchingRule(blnkgo.Matcher{
+		Name:        fmt.Sprintf("Issue44 rule %d", time.Now().UnixNano()),
+		Description: "Rule to delete",
+		Criteria: []blnkgo.Criteria{
+			{
+				Field:    blnkgo.CriteriaFieldAmount,
+				Operator: blnkgo.ReconciliationOperatorEquals,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, created.RuleID)
+
+	deleted, resp, err := client.Reconciliation.DeleteMatchingRule(created.RuleID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, deleted.Message)
+}
+
+func TestIssue44_DeleteMatchingRule_EmptyID(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Reconciliation.DeleteMatchingRule("")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "matching rule id is required")
+}
+
+func TestIssue44_DeleteMatchingRule_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Reconciliation.DeleteMatchingRule("rule_nonexistent_issue44")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}

--- a/reconciliation.go
+++ b/reconciliation.go
@@ -44,6 +44,11 @@ type RunReconResp struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
+// DeleteMatchingRuleResp is returned when a matching rule is deleted.
+type DeleteMatchingRuleResp struct {
+	Message string `json:"message"`
+}
+
 // ExternalTransaction is a single row of external data for instant reconciliation.
 // Description, Date, and Source are optional at the Core HTTP layer; omit them when unset.
 type ExternalTransaction struct {
@@ -116,6 +121,25 @@ func (s *ReconciliationService) UpdateMatchingRule(ruleID string, matcher Matche
 	}
 
 	return reconResp, resp, nil
+}
+
+func (s *ReconciliationService) DeleteMatchingRule(ruleID string) (*DeleteMatchingRuleResp, *http.Response, error) {
+	if ruleID == "" {
+		return nil, nil, fmt.Errorf("matching rule id is required")
+	}
+
+	req, err := s.client.NewRequest(fmt.Sprintf("reconciliation/matching-rules/%s", ruleID), http.MethodDelete, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deleteResp := new(DeleteMatchingRuleResp)
+	resp, err := s.client.CallWithRetry(req, deleteResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return deleteResp, resp, nil
 }
 
 func (s *ReconciliationService) RunInstant(data RunInstantReconData) (*RunInstantReconResp, *http.Response, error) {

--- a/reconciliation_test.go
+++ b/reconciliation_test.go
@@ -549,3 +549,69 @@ func TestReconciliationService_UpdateMatchingRule_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, httpResp.StatusCode)
 	mockClient.AssertExpectations(t)
 }
+
+func TestReconciliationService_DeleteMatchingRule_Success(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	ruleID := "rule_abc123"
+	expected := &blnkgo.DeleteMatchingRuleResp{
+		Message: "Matching rule deleted successfully",
+	}
+
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/matching-rules/%s", ruleID), http.MethodDelete, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.DeleteMatchingRuleResp)
+		*resp = *expected
+	})
+
+	result, httpResp, err := svc.DeleteMatchingRule(ruleID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, expected, result)
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_DeleteMatchingRule_EmptyID(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	result, httpResp, err := svc.DeleteMatchingRule("")
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "matching rule id is required")
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_DeleteMatchingRule_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	ruleID := "rule_abc123"
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/matching-rules/%s", ruleID), http.MethodDelete, nil).Return(nil, errors.New("failed to create request"))
+
+	result, httpResp, err := svc.DeleteMatchingRule(ruleID)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "failed to create request")
+	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_DeleteMatchingRule_NotFound(t *testing.T) {
+	mockClient, svc := setupReconciliationService()
+
+	ruleID := "rule_missing"
+	mockClient.On("NewRequest", fmt.Sprintf("reconciliation/matching-rules/%s", ruleID), http.MethodDelete, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusNotFound}, errors.New("not found"))
+
+	result, httpResp, err := svc.DeleteMatchingRule(ruleID)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusNotFound, httpResp.StatusCode)
+	mockClient.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- Add `Reconciliation.DeleteMatchingRule` calling `DELETE /reconciliation/matching-rules/{rule_id}`
- Add `DeleteMatchingRuleResp` with `message` field matching Core response
- Client-side check: empty rule id rejected before HTTP call
- Unit tests (mocked HTTP) and integration tests against Core 0.14.x

## Acceptance criteria (#44)
- [x] `Reconciliation.DeleteMatchingRule` → `/reconciliation/matching-rules/{rule_id}`
- [x] Request/response Go types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] README usage example

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue44 ./integration/...`

Closes #44