### PR TITLE
Add Health.Check for GET /health (closes #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,18 @@ fmt.Println("Matched:", recon.MatchedTransactions)
 fmt.Println("Unmatched:", recon.UnmatchedTransactions)
 ```
 
+### Health
+
+Check whether Blnk Core is running and reachable:
+
+```go
+health, resp, err := client.Health.Check()
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Status:", health.Status) // UP when Core is healthy
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/client.go
+++ b/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	Search         *SearchService
 	Reconciliation *ReconciliationService
 	Metadata       *MetadataService
+	Health         *HealthService
 }
 
 // create a client interface
@@ -98,6 +99,7 @@ func NewClient(baseURL *url.URL, apiKey *string, opts ...ClientOption) *Client {
 	client.Search = &SearchService{client: client}
 	client.Reconciliation = &ReconciliationService{client: client}
 	client.Metadata = &MetadataService{client: client}
+	client.Health = &HealthService{client: client}
 
 	return client
 }

--- a/health.go
+++ b/health.go
@@ -1,0 +1,31 @@
+package blnkgo
+
+import "net/http"
+
+type HealthService service
+
+// HealthResponse is returned by GET /health when Blnk Core is reachable.
+type HealthResponse struct {
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// Check verifies that Blnk Core is running and reachable.
+func (s *HealthService) Check() (*HealthResponse, *http.Response, error) {
+	req, err := s.client.NewRequest("health", http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	healthResp := new(HealthResponse)
+	resp, err := s.client.CallWithRetry(req, healthResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return healthResp, resp, nil
+}
+
+func NewHealthService(client ClientInterface) *HealthService {
+	return &HealthService{client: client}
+}

--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,66 @@
+package blnkgo_test
+
+import (
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupHealthService() (*MockClient, *blnkgo.HealthService) {
+	mockClient := &MockClient{}
+	svc := blnkgo.NewHealthService(mockClient)
+	return mockClient, svc
+}
+
+func TestHealthService_Check_Success(t *testing.T) {
+	mockClient, svc := setupHealthService()
+
+	mockClient.On("NewRequest", "health", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.HealthResponse)
+		*resp = blnkgo.HealthResponse{Status: "UP"}
+	})
+
+	healthResp, httpResp, err := svc.Check()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "UP", healthResp.Status)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHealthService_Check_ServiceUnavailable(t *testing.T) {
+	mockClient, svc := setupHealthService()
+
+	mockClient.On("NewRequest", "health", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusServiceUnavailable}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.HealthResponse)
+		*resp = blnkgo.HealthResponse{Status: "DOWN", Reason: "database ping failed"}
+	})
+
+	healthResp, httpResp, err := svc.Check()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusServiceUnavailable, httpResp.StatusCode)
+	assert.Equal(t, "DOWN", healthResp.Status)
+	assert.Equal(t, "database ping failed", healthResp.Reason)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHealthService_Check_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupHealthService()
+
+	mockClient.On("NewRequest", "health", http.MethodGet, nil).Return(nil, assert.AnError)
+
+	healthResp, httpResp, err := svc.Check()
+
+	assert.Error(t, err)
+	assert.Nil(t, healthResp)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -26,6 +26,7 @@ go test -tags=integration -v ./integration/... -run Issue42
 go test -tags=integration -v ./integration/... -run Issue43
 go test -tags=integration -v ./integration/... -run Issue44
 go test -tags=integration -v ./integration/... -run Issue36
+go test -tags=integration -v ./integration/... -run Issue61
 
 # all integration tests
 go test -tags=integration -v ./integration/... 
@@ -56,6 +57,7 @@ go test -tags=integration -v ./integration/...
 | #43 update matching rule | 0.14.x+ | PUT /reconciliation/matching-rules/{rule_id} |
 | #44 delete matching rule | 0.14.x+ | DELETE /reconciliation/matching-rules/{rule_id} |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
+| #61 health check | 0.14.x+ | GET /health; auth not required |
 | 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue61_test.go
+++ b/integration/issue61_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+// Integration tests for issue #61 — Health.Check (GET /health).
+// Requires Blnk Core running at http://localhost:5001 (docker compose up in blnk/).
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue61
+package integration
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newHealthClient(t *testing.T) *blnkgo.Client {
+	t.Helper()
+	u := integrationBaseURL(t)
+	// Health does not require authentication; API key is optional.
+	return blnkgo.NewClient(u, nil, blnkgo.WithTimeout(15*time.Second), blnkgo.WithRetry(2))
+}
+
+func TestIssue61_HealthCheck(t *testing.T) {
+	client := newHealthClient(t)
+
+	health, resp, err := client.Health.Check()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, health)
+	require.Equal(t, "UP", health.Status)
+}
+
+func TestIssue61_HealthCheck_WithAPIKey(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	health, resp, err := client.Health.Check()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "UP", health.Status)
+}
+
+func TestIssue61_HealthCheck_InvalidBaseURL(t *testing.T) {
+	u, err := url.Parse("http://localhost:59999/")
+	require.NoError(t, err)
+
+	client := blnkgo.NewClient(u, nil, blnkgo.WithTimeout(2*time.Second), blnkgo.WithRetry(1))
+	_, resp, err := client.Health.Check()
+	require.Error(t, err)
+	if resp != nil {
+		require.NotEqual(t, http.StatusOK, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `HealthService.Check()` calling `GET /health`
- Wire `client.Health` on the SDK client
- Add unit tests and integration tests (`integration/issue61_test.go`)
- Document usage in README

## Test plan
- [x] `go test ./... -run Health`
- [x] `go test -tags=integration -run Issue61` against Core 0.14.5
- [x] Postman: `TEST — #61 Health (run this folder only)` — both requests return 200 `{"status":"UP"}`