### PR TITLE
Add ApiKeys.Create for POST /api-keys (closes #58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,6 +807,24 @@ if err != nil {
 fmt.Println("Status:", health.Status) // UP when Core is healthy
 ```
 
+### API keys
+
+Create a scoped API key (requires master key or `api-keys:write` scope):
+
+```go
+apiKey, resp, err := client.ApiKeys.Create(blnkgo.CreateApiKeyRequest{
+    Name:      "read-only-ledger",
+    Owner:     "team_acme",
+    Scopes:    []string{"ledgers:read"},
+    ExpiresAt: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Key ID:", apiKey.ApiKeyID)
+fmt.Println("Secret:", apiKey.Key) // store securely; shown once on create
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/api_keys.go
+++ b/api_keys.go
@@ -1,0 +1,54 @@
+package blnkgo
+
+import (
+	"net/http"
+	"time"
+)
+
+type ApiKeysService service
+
+// CreateApiKeyRequest is the body for POST /api-keys.
+type CreateApiKeyRequest struct {
+	Name      string    `json:"name"`
+	Owner     string    `json:"owner"`
+	Scopes    []string  `json:"scopes"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// ApiKeyResponse is returned when an API key is created, listed, or fetched.
+type ApiKeyResponse struct {
+	ApiKeyID   string   `json:"api_key_id"`
+	Key        string   `json:"key"`
+	Name       string   `json:"name"`
+	OwnerID    string   `json:"owner_id"`
+	Scopes     []string `json:"scopes"`
+	ExpiresAt  string   `json:"expires_at"`
+	CreatedAt  string   `json:"created_at"`
+	LastUsedAt string   `json:"last_used_at"`
+	IsRevoked  bool     `json:"is_revoked"`
+	RevokedAt  string   `json:"revoked_at,omitempty"`
+}
+
+// Create issues a new scoped API key.
+func (s *ApiKeysService) Create(body CreateApiKeyRequest) (*ApiKeyResponse, *http.Response, error) {
+	if err := ValidateCreateApiKeyRequest(body); err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("api-keys", http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	apiKeyResp := new(ApiKeyResponse)
+	resp, err := s.client.CallWithRetry(req, apiKeyResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return apiKeyResp, resp, nil
+}
+
+func NewApiKeysService(client ClientInterface) *ApiKeysService {
+	return &ApiKeysService{client: client}
+}

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -1,0 +1,88 @@
+package blnkgo_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupApiKeysService() (*MockClient, *blnkgo.ApiKeysService) {
+	mockClient := &MockClient{}
+	svc := blnkgo.NewApiKeysService(mockClient)
+	return mockClient, svc
+}
+
+func TestApiKeysService_Create_Success(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	expiresAt := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	body := blnkgo.CreateApiKeyRequest{
+		Name:      "integration-key",
+		Owner:     "owner_test",
+		Scopes:    []string{"ledgers:read"},
+		ExpiresAt: expiresAt,
+	}
+
+	mockClient.On("NewRequest", "api-keys", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusCreated}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.ApiKeyResponse)
+		*resp = blnkgo.ApiKeyResponse{
+			ApiKeyID:  "api_key_abc123",
+			Key:       "secret-key-value",
+			Name:      body.Name,
+			OwnerID:   body.Owner,
+			Scopes:    body.Scopes,
+			ExpiresAt: expiresAt.Format(time.RFC3339),
+			CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			IsRevoked: false,
+		}
+	})
+
+	apiKeyResp, httpResp, err := svc.Create(body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusCreated, httpResp.StatusCode)
+	assert.Equal(t, "api_key_abc123", apiKeyResp.ApiKeyID)
+	assert.Equal(t, "secret-key-value", apiKeyResp.Key)
+	assert.Equal(t, body.Owner, apiKeyResp.OwnerID)
+	mockClient.AssertExpectations(t)
+}
+
+func TestApiKeysService_Create_ValidationError(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	_, _, err := svc.Create(blnkgo.CreateApiKeyRequest{
+		Name:  "missing-fields",
+		Owner: "owner_test",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one scope must be specified")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestApiKeysService_Create_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	body := blnkgo.CreateApiKeyRequest{
+		Name:      "test-key",
+		Owner:     "owner_test",
+		Scopes:    []string{"ledgers:read"},
+		ExpiresAt: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	mockClient.On("NewRequest", "api-keys", http.MethodPost, body).Return(nil, errors.New("failed to create request"))
+
+	apiKeyResp, httpResp, err := svc.Create(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, apiKeyResp)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/client.go
+++ b/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	Reconciliation *ReconciliationService
 	Metadata       *MetadataService
 	Health         *HealthService
+	ApiKeys        *ApiKeysService
 }
 
 // create a client interface
@@ -100,6 +101,7 @@ func NewClient(baseURL *url.URL, apiKey *string, opts ...ClientOption) *Client {
 	client.Reconciliation = &ReconciliationService{client: client}
 	client.Metadata = &MetadataService{client: client}
 	client.Health = &HealthService{client: client}
+	client.ApiKeys = &ApiKeysService{client: client}
 
 	return client
 }

--- a/integration/README.md
+++ b/integration/README.md
@@ -27,6 +27,7 @@ go test -tags=integration -v ./integration/... -run Issue43
 go test -tags=integration -v ./integration/... -run Issue44
 go test -tags=integration -v ./integration/... -run Issue36
 go test -tags=integration -v ./integration/... -run Issue61
+go test -tags=integration -v ./integration/... -run Issue58
 
 # all integration tests
 go test -tags=integration -v ./integration/... 
@@ -58,6 +59,7 @@ go test -tags=integration -v ./integration/...
 | #44 delete matching rule | 0.14.x+ | DELETE /reconciliation/matching-rules/{rule_id} |
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | #61 health check | 0.14.x+ | GET /health; auth not required |
-| 0.15-only features (delete identity, hooks, api-keys, etc.) | 0.15.0 | Test when we reach Go 1.3.0 issues |
+| #58 create api key | 0.14.x+ | POST /api-keys; master or api-keys:write key |
+| 0.15-only features (delete identity, hooks, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue58_test.go
+++ b/integration/issue58_test.go
@@ -1,0 +1,53 @@
+//go:build integration
+
+// Integration tests for issue #58 — ApiKeys.Create (POST /api-keys).
+// Requires Blnk Core running at http://localhost:5001 with a master or api-keys:write key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue58
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue58_CreateApiKey(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	owner := fmt.Sprintf("owner_issue58_%d", time.Now().UnixNano())
+	expiresAt := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+
+	apiKey, resp, err := client.ApiKeys.Create(blnkgo.CreateApiKeyRequest{
+		Name:      fmt.Sprintf("issue58-key-%d", time.Now().UnixNano()),
+		Owner:     owner,
+		Scopes:    []string{"ledgers:read"},
+		ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotNil(t, apiKey)
+	require.NotEmpty(t, apiKey.ApiKeyID)
+	require.Contains(t, apiKey.ApiKeyID, "api_key_")
+	require.NotEmpty(t, apiKey.Key)
+	require.Equal(t, owner, apiKey.OwnerID)
+	require.Equal(t, []string{"ledgers:read"}, apiKey.Scopes)
+	require.False(t, apiKey.IsRevoked)
+}
+
+func TestIssue58_CreateApiKey_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.ApiKeys.Create(blnkgo.CreateApiKeyRequest{
+		Name:  "invalid",
+		Owner: "owner_test",
+	})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "at least one scope must be specified")
+}

--- a/validate_api_key.go
+++ b/validate_api_key.go
@@ -1,0 +1,28 @@
+package blnkgo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateCreateApiKeyRequest performs client-side checks before POST /api-keys.
+func ValidateCreateApiKeyRequest(body CreateApiKeyRequest) error {
+	if strings.TrimSpace(body.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	if strings.TrimSpace(body.Owner) == "" {
+		return fmt.Errorf("owner is required")
+	}
+	if len(body.Scopes) == 0 {
+		return fmt.Errorf("at least one scope must be specified")
+	}
+	for _, scope := range body.Scopes {
+		if strings.TrimSpace(scope) == "" {
+			return fmt.Errorf("each scope must be a non-empty string")
+		}
+	}
+	if body.ExpiresAt.IsZero() {
+		return fmt.Errorf("expires_at is required")
+	}
+	return nil
+}

--- a/validate_api_key_test.go
+++ b/validate_api_key_test.go
@@ -1,0 +1,24 @@
+package blnkgo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateCreateApiKeyRequest(t *testing.T) {
+	valid := CreateApiKeyRequest{
+		Name:      "my-key",
+		Owner:     "owner_1",
+		Scopes:    []string{"ledgers:read"},
+		ExpiresAt: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	assert.NoError(t, ValidateCreateApiKeyRequest(valid))
+	assert.Error(t, ValidateCreateApiKeyRequest(CreateApiKeyRequest{Owner: "o", Scopes: []string{"s"}, ExpiresAt: valid.ExpiresAt}))
+	assert.Error(t, ValidateCreateApiKeyRequest(CreateApiKeyRequest{Name: "n", Scopes: []string{"s"}, ExpiresAt: valid.ExpiresAt}))
+	assert.Error(t, ValidateCreateApiKeyRequest(CreateApiKeyRequest{Name: "n", Owner: "o", ExpiresAt: valid.ExpiresAt}))
+	assert.Error(t, ValidateCreateApiKeyRequest(CreateApiKeyRequest{Name: "n", Owner: "o", Scopes: []string{""}, ExpiresAt: valid.ExpiresAt}))
+	assert.Error(t, ValidateCreateApiKeyRequest(CreateApiKeyRequest{Name: "n", Owner: "o", Scopes: []string{"s"}}))
+}


### PR DESCRIPTION
## Summary
- Add `ApiKeysService.Create()` calling `POST /api-keys`
- Add request/response types and client-side validation
- Wire `client.ApiKeys` on the SDK client
- Add unit tests and integration tests (`integration/issue58_test.go`)
- Document usage in README

## Test plan
- [x] `go test ./... -run ApiKey`
- [x] `go test -tags=integration -run Issue58` against Core 0.14.5
- [x] Postman: `TEST — #58 Create API key (run this folder only)` — expect 201 with `api_key_id` and `key`