### PR TITLE
Add ApiKeys.List for GET /api-keys (closes #59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,20 @@ fmt.Println("Key ID:", apiKey.ApiKeyID)
 fmt.Println("Secret:", apiKey.Key) // store securely; shown once on create
 ```
 
+List API keys for an owner (master key requires the `owner` query parameter):
+
+```go
+keys, resp, err := client.ApiKeys.List(&blnkgo.ListApiKeysOptions{
+    Owner: "team_acme",
+})
+if err != nil {
+    log.Fatal(err)
+}
+for _, key := range keys {
+    fmt.Println(key.ApiKeyID, key.Name, key.Scopes)
+}
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/api_keys.go
+++ b/api_keys.go
@@ -49,6 +49,36 @@ func (s *ApiKeysService) Create(body CreateApiKeyRequest) (*ApiKeyResponse, *htt
 	return apiKeyResp, resp, nil
 }
 
+// ListApiKeysOptions filters GET /api-keys results.
+type ListApiKeysOptions struct {
+	Owner string `url:"owner,omitempty"`
+}
+
+// List returns API keys for an owner. Pass ListApiKeysOptions with Owner when using a master key.
+func (s *ApiKeysService) List(options *ListApiKeysOptions) ([]ApiKeyResponse, *http.Response, error) {
+	if err := ValidateListApiKeysOptions(options); err != nil {
+		return nil, nil, err
+	}
+
+	var query interface{}
+	if options != nil {
+		query = options
+	}
+
+	req, err := s.client.NewRequest("api-keys", http.MethodGet, query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var keys []ApiKeyResponse
+	resp, err := s.client.CallWithRetry(req, &keys)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return keys, resp, nil
+}
+
 func NewApiKeysService(client ClientInterface) *ApiKeysService {
 	return &ApiKeysService{client: client}
 }

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -9,6 +9,7 @@ import (
 	blnkgo "github.com/blnkfinance/blnk-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func setupApiKeysService() (*MockClient, *blnkgo.ApiKeysService) {
@@ -83,6 +84,76 @@ func TestApiKeysService_Create_RequestCreationFailure(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, apiKeyResp)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestApiKeysService_List_Success(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	opts := &blnkgo.ListApiKeysOptions{Owner: "owner_test"}
+	mockClient.On("NewRequest", "api-keys", http.MethodGet, opts).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		keys := args.Get(1).(*[]blnkgo.ApiKeyResponse)
+		*keys = []blnkgo.ApiKeyResponse{
+			{
+				ApiKeyID:  "api_key_abc123",
+				Name:      "read-only",
+				OwnerID:   "owner_test",
+				Scopes:    []string{"ledgers:read"},
+				IsRevoked: false,
+			},
+		}
+	})
+
+	keys, httpResp, err := svc.List(opts)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "api_key_abc123", keys[0].ApiKeyID)
+	assert.Equal(t, "owner_test", keys[0].OwnerID)
+	mockClient.AssertExpectations(t)
+}
+
+func TestApiKeysService_List_WithoutOptions(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	mockClient.On("NewRequest", "api-keys", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		keys := args.Get(1).(*[]blnkgo.ApiKeyResponse)
+		*keys = []blnkgo.ApiKeyResponse{}
+	})
+
+	keys, httpResp, err := svc.List(nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Empty(t, keys)
+	mockClient.AssertExpectations(t)
+}
+
+func TestApiKeysService_List_ValidationError(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	_, _, err := svc.List(&blnkgo.ListApiKeysOptions{Owner: "   "})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "owner must be a non-empty string")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestApiKeysService_List_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	opts := &blnkgo.ListApiKeysOptions{Owner: "owner_test"}
+	mockClient.On("NewRequest", "api-keys", http.MethodGet, opts).Return(nil, errors.New("failed to create request"))
+
+	keys, httpResp, err := svc.List(opts)
+
+	assert.Error(t, err)
+	assert.Nil(t, keys)
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }

--- a/integration/README.md
+++ b/integration/README.md
@@ -28,6 +28,7 @@ go test -tags=integration -v ./integration/... -run Issue44
 go test -tags=integration -v ./integration/... -run Issue36
 go test -tags=integration -v ./integration/... -run Issue61
 go test -tags=integration -v ./integration/... -run Issue58
+go test -tags=integration -v ./integration/... -run Issue59
 
 # all integration tests
 go test -tags=integration -v ./integration/... 
@@ -60,6 +61,7 @@ go test -tags=integration -v ./integration/...
 | #36 transaction lineage | 0.14.x+ | Not 0.15-only |
 | #61 health check | 0.14.x+ | GET /health; auth not required |
 | #58 create api key | 0.14.x+ | POST /api-keys; master or api-keys:write key |
+| #59 list api keys | 0.14.x+ | GET /api-keys?owner=; master requires owner |
 | 0.15-only features (delete identity, hooks, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue59_test.go
+++ b/integration/issue59_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+// Integration tests for issue #59 — ApiKeys.List (GET /api-keys).
+// Requires Blnk Core running at http://localhost:5001 with a master or api-keys:read key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue59
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue59_ListApiKeys(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	owner := fmt.Sprintf("owner_issue59_%d", time.Now().UnixNano())
+	keyName := fmt.Sprintf("issue59-key-%d", time.Now().UnixNano())
+	expiresAt := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+
+	created, createResp, err := client.ApiKeys.Create(blnkgo.CreateApiKeyRequest{
+		Name:      keyName,
+		Owner:     owner,
+		Scopes:    []string{"ledgers:read"},
+		ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	require.NotEmpty(t, created.ApiKeyID)
+
+	keys, listResp, err := client.ApiKeys.List(&blnkgo.ListApiKeysOptions{Owner: owner})
+	require.NoError(t, err)
+	require.NotNil(t, listResp)
+	require.Equal(t, http.StatusOK, listResp.StatusCode)
+	require.NotEmpty(t, keys)
+
+	found := false
+	for _, key := range keys {
+		if key.ApiKeyID == created.ApiKeyID {
+			found = true
+			require.Equal(t, owner, key.OwnerID)
+			require.Equal(t, keyName, key.Name)
+			require.Equal(t, []string{"ledgers:read"}, key.Scopes)
+			require.False(t, key.IsRevoked)
+			break
+		}
+	}
+	require.True(t, found, "expected created API key in list response")
+}
+
+func TestIssue59_ListApiKeys_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.ApiKeys.List(&blnkgo.ListApiKeysOptions{Owner: "   "})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "owner must be a non-empty string")
+}

--- a/validate_api_key.go
+++ b/validate_api_key.go
@@ -26,3 +26,14 @@ func ValidateCreateApiKeyRequest(body CreateApiKeyRequest) error {
 	}
 	return nil
 }
+
+// ValidateListApiKeysOptions performs client-side checks before GET /api-keys.
+func ValidateListApiKeysOptions(options *ListApiKeysOptions) error {
+	if options == nil {
+		return nil
+	}
+	if options.Owner != "" && strings.TrimSpace(options.Owner) == "" {
+		return fmt.Errorf("owner must be a non-empty string")
+	}
+	return nil
+}

--- a/validate_api_key_test.go
+++ b/validate_api_key_test.go
@@ -22,3 +22,10 @@ func TestValidateCreateApiKeyRequest(t *testing.T) {
 	assert.Error(t, ValidateCreateApiKeyRequest(CreateApiKeyRequest{Name: "n", Owner: "o", Scopes: []string{""}, ExpiresAt: valid.ExpiresAt}))
 	assert.Error(t, ValidateCreateApiKeyRequest(CreateApiKeyRequest{Name: "n", Owner: "o", Scopes: []string{"s"}}))
 }
+
+func TestValidateListApiKeysOptions(t *testing.T) {
+	assert.NoError(t, ValidateListApiKeysOptions(nil))
+	assert.NoError(t, ValidateListApiKeysOptions(&ListApiKeysOptions{}))
+	assert.NoError(t, ValidateListApiKeysOptions(&ListApiKeysOptions{Owner: "owner_1"}))
+	assert.Error(t, ValidateListApiKeysOptions(&ListApiKeysOptions{Owner: "   "}))
+}


### PR DESCRIPTION
## Summary
- Add `ApiKeysService.List()` calling `GET /api-keys` with optional `owner` query filter
- Add `ListApiKeysOptions` and client-side validation
- Add unit tests and integration tests (`integration/issue59_test.go`)
- Document usage in README

## Test plan
- [x] `go test ./... -run ApiKey`
- [x] `go test -tags=integration -run Issue59` against Core 0.14.5
- [x] Postman: `TEST — #59 List API keys (run this folder only)` — setup create (201), then list (200)