### PR TITLE
Add ApiKeys.Delete for DELETE /api-keys/{id} (closes #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,18 @@ for _, key := range keys {
 }
 ```
 
+Revoke an API key by ID (master key requires the `owner` query parameter):
+
+```go
+resp, err := client.ApiKeys.Delete("api_key_abc123", &blnkgo.DeleteApiKeysOptions{
+    Owner: "team_acme",
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Revoked, status:", resp.StatusCode) // 204 No Content
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/api_keys.go
+++ b/api_keys.go
@@ -1,7 +1,9 @@
 package blnkgo
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -77,6 +79,36 @@ func (s *ApiKeysService) List(options *ListApiKeysOptions) ([]ApiKeyResponse, *h
 	}
 
 	return keys, resp, nil
+}
+
+// DeleteApiKeysOptions sets optional query params for DELETE /api-keys/{id}.
+type DeleteApiKeysOptions struct {
+	Owner string
+}
+
+// Delete revokes an API key by ID. Pass DeleteApiKeysOptions with Owner when using a master key.
+func (s *ApiKeysService) Delete(apiKeyID string, options *DeleteApiKeysOptions) (*http.Response, error) {
+	if err := ValidateDeleteApiKeys(apiKeyID, options); err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("api-keys/%s", apiKeyID)
+	if options != nil && options.Owner != "" {
+		endpoint += "?owner=" + url.QueryEscape(options.Owner)
+	}
+
+	req, err := s.client.NewRequest(endpoint, http.MethodDelete, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var discard struct{}
+	resp, err := s.client.CallWithRetry(req, &discard)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
 }
 
 func NewApiKeysService(client ClientInterface) *ApiKeysService {

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -157,3 +157,57 @@ func TestApiKeysService_List_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestApiKeysService_Delete_Success(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	apiKeyID := "api_key_abc123"
+	opts := &blnkgo.DeleteApiKeysOptions{Owner: "owner_test"}
+	mockClient.On("NewRequest", "api-keys/"+apiKeyID+"?owner=owner_test", http.MethodDelete, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusNoContent}, nil)
+
+	httpResp, err := svc.Delete(apiKeyID, opts)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusNoContent, httpResp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestApiKeysService_Delete_WithoutOptions(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	apiKeyID := "api_key_abc123"
+	mockClient.On("NewRequest", "api-keys/"+apiKeyID, http.MethodDelete, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusNoContent}, nil)
+
+	httpResp, err := svc.Delete(apiKeyID, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, httpResp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestApiKeysService_Delete_ValidationError(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	httpResp, err := svc.Delete("", nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "api key id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestApiKeysService_Delete_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupApiKeysService()
+
+	apiKeyID := "api_key_abc123"
+	mockClient.On("NewRequest", "api-keys/"+apiKeyID, http.MethodDelete, nil).Return(nil, errors.New("failed to create request"))
+
+	httpResp, err := svc.Delete(apiKeyID, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/client.go
+++ b/client.go
@@ -227,6 +227,10 @@ func (c *Client) DecodeResponse(resp *http.Response, v interface{}) error {
 		return err
 	}
 
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(v)
 	if err != nil {
 		return err

--- a/integration/README.md
+++ b/integration/README.md
@@ -62,6 +62,7 @@ go test -tags=integration -v ./integration/...
 | #61 health check | 0.14.x+ | GET /health; auth not required |
 | #58 create api key | 0.14.x+ | POST /api-keys; master or api-keys:write key |
 | #59 list api keys | 0.14.x+ | GET /api-keys?owner=; master requires owner |
+| #60 delete api key | 0.14.x+ | DELETE /api-keys/{id}?owner=; master requires owner |
 | 0.15-only features (delete identity, hooks, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue60_test.go
+++ b/integration/issue60_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+// Integration tests for issue #60 — ApiKeys.Delete (DELETE /api-keys/{id}).
+// Requires Blnk Core running at http://localhost:5001 with a master or api-keys:write key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue60
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue60_DeleteApiKey(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	owner := fmt.Sprintf("owner_issue60_%d", time.Now().UnixNano())
+	keyName := fmt.Sprintf("issue60-key-%d", time.Now().UnixNano())
+	expiresAt := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+
+	created, createResp, err := client.ApiKeys.Create(blnkgo.CreateApiKeyRequest{
+		Name:      keyName,
+		Owner:     owner,
+		Scopes:    []string{"ledgers:read"},
+		ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	require.NotEmpty(t, created.ApiKeyID)
+
+	deleteResp, err := client.ApiKeys.Delete(created.ApiKeyID, &blnkgo.DeleteApiKeysOptions{Owner: owner})
+	require.NoError(t, err)
+	require.NotNil(t, deleteResp)
+	require.Equal(t, http.StatusNoContent, deleteResp.StatusCode)
+
+	keys, listResp, err := client.ApiKeys.List(&blnkgo.ListApiKeysOptions{Owner: owner})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, listResp.StatusCode)
+
+	found := false
+	for _, key := range keys {
+		if key.ApiKeyID == created.ApiKeyID {
+			found = true
+			require.True(t, key.IsRevoked)
+			break
+		}
+	}
+	require.True(t, found, "expected revoked API key in list response")
+}
+
+func TestIssue60_DeleteApiKey_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	resp, err := client.ApiKeys.Delete("", nil)
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "api key id is required")
+}
+
+func TestIssue60_DeleteApiKey_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	resp, err := client.ApiKeys.Delete("api_key_nonexistent_issue60", &blnkgo.DeleteApiKeysOptions{Owner: "owner_issue60"})
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/validate_api_key.go
+++ b/validate_api_key.go
@@ -37,3 +37,14 @@ func ValidateListApiKeysOptions(options *ListApiKeysOptions) error {
 	}
 	return nil
 }
+
+// ValidateDeleteApiKeys performs client-side checks before DELETE /api-keys/{id}.
+func ValidateDeleteApiKeys(apiKeyID string, options *DeleteApiKeysOptions) error {
+	if strings.TrimSpace(apiKeyID) == "" {
+		return fmt.Errorf("api key id is required")
+	}
+	if options != nil && options.Owner != "" && strings.TrimSpace(options.Owner) == "" {
+		return fmt.Errorf("owner must be a non-empty string")
+	}
+	return nil
+}

--- a/validate_api_key_test.go
+++ b/validate_api_key_test.go
@@ -29,3 +29,12 @@ func TestValidateListApiKeysOptions(t *testing.T) {
 	assert.NoError(t, ValidateListApiKeysOptions(&ListApiKeysOptions{Owner: "owner_1"}))
 	assert.Error(t, ValidateListApiKeysOptions(&ListApiKeysOptions{Owner: "   "}))
 }
+
+func TestValidateDeleteApiKeys(t *testing.T) {
+	assert.NoError(t, ValidateDeleteApiKeys("api_key_abc123", nil))
+	assert.NoError(t, ValidateDeleteApiKeys("api_key_abc123", &DeleteApiKeysOptions{}))
+	assert.NoError(t, ValidateDeleteApiKeys("api_key_abc123", &DeleteApiKeysOptions{Owner: "owner_1"}))
+	assert.Error(t, ValidateDeleteApiKeys("", nil))
+	assert.Error(t, ValidateDeleteApiKeys("   ", nil))
+	assert.Error(t, ValidateDeleteApiKeys("api_key_abc123", &DeleteApiKeysOptions{Owner: "   "}))
+}


### PR DESCRIPTION
## Summary
- Add `ApiKeysService.Delete()` calling `DELETE /api-keys/{id}` with optional `owner` query filter
- Add `DeleteApiKeysOptions` and client-side validation
- Skip JSON decode on `204 No Content` in `DecodeResponse` (required for revoke endpoint)
- Add unit tests and integration tests (`integration/issue60_test.go`)
- Document usage in README

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue60` against Core 0.14.5
- [x] Postman: `TEST — #60 Delete API key (run this folder only)` — setup create (201), then delete (204)