### PR TITLE
Add Hooks.Create for POST /hooks (closes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,25 @@ if err != nil {
 fmt.Println("Revoked, status:", resp.StatusCode) // 204 No Content
 ```
 
+### Hooks
+
+Register a pre- or post-transaction webhook (master key required):
+
+```go
+hook, resp, err := client.Hooks.Create(blnkgo.CreateHookRequest{
+    Name:       "Pre-transaction validation",
+    URL:        "https://api.example.com/validate",
+    Type:       blnkgo.HookTypePreTransaction,
+    Active:     true,
+    Timeout:    30,
+    RetryCount: 3,
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Hook ID:", hook.ID)
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/client.go
+++ b/client.go
@@ -31,6 +31,7 @@ type Client struct {
 	Metadata       *MetadataService
 	Health         *HealthService
 	ApiKeys        *ApiKeysService
+	Hooks          *HooksService
 }
 
 // create a client interface
@@ -102,6 +103,7 @@ func NewClient(baseURL *url.URL, apiKey *string, opts ...ClientOption) *Client {
 	client.Metadata = &MetadataService{client: client}
 	client.Health = &HealthService{client: client}
 	client.ApiKeys = &ApiKeysService{client: client}
+	client.Hooks = &HooksService{client: client}
 
 	return client
 }

--- a/hooks.go
+++ b/hooks.go
@@ -1,0 +1,61 @@
+package blnkgo
+
+import "net/http"
+
+type HooksService service
+
+// HookType identifies when a webhook runs relative to a transaction.
+type HookType string
+
+const (
+	HookTypePreTransaction  HookType = "PRE_TRANSACTION"
+	HookTypePostTransaction HookType = "POST_TRANSACTION"
+)
+
+// CreateHookRequest is the body for POST /hooks.
+type CreateHookRequest struct {
+	Name       string   `json:"name"`
+	URL        string   `json:"url"`
+	Type       HookType `json:"type"`
+	Active     bool     `json:"active"`
+	Timeout    int      `json:"timeout"`
+	RetryCount int      `json:"retry_count"`
+}
+
+// HookResponse is returned when a hook is created, listed, fetched, or updated.
+type HookResponse struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	URL         string   `json:"url"`
+	Type        HookType `json:"type"`
+	Active      bool     `json:"active"`
+	Timeout     int      `json:"timeout"`
+	RetryCount  int      `json:"retry_count"`
+	CreatedAt   string   `json:"created_at"`
+	LastRun     string   `json:"last_run"`
+	LastSuccess bool     `json:"last_success"`
+}
+
+// Create registers a new webhook (master key required).
+func (s *HooksService) Create(body CreateHookRequest) (*HookResponse, *http.Response, error) {
+	if err := ValidateCreateHookRequest(body); err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("hooks", http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hookResp := new(HookResponse)
+	resp, err := s.client.CallWithRetry(req, hookResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hookResp, resp, nil
+}
+
+func NewHooksService(client ClientInterface) *HooksService {
+	return &HooksService{client: client}
+}

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -1,0 +1,95 @@
+package blnkgo_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupHooksService() (*MockClient, *blnkgo.HooksService) {
+	mockClient := &MockClient{}
+	svc := blnkgo.NewHooksService(mockClient)
+	return mockClient, svc
+}
+
+func TestHooksService_Create_Success(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	body := blnkgo.CreateHookRequest{
+		Name:       "Pre-transaction validation",
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	}
+
+	mockClient.On("NewRequest", "hooks", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusCreated}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.HookResponse)
+		*resp = blnkgo.HookResponse{
+			ID:          "hk_test_123",
+			Name:        body.Name,
+			URL:         body.URL,
+			Type:        body.Type,
+			Active:      body.Active,
+			Timeout:     body.Timeout,
+			RetryCount:  body.RetryCount,
+			CreatedAt:   "2024-11-26T08:36:36.238244338Z",
+			LastRun:     "0001-01-01T00:00:00Z",
+			LastSuccess: false,
+		}
+	})
+
+	hook, httpResp, err := svc.Create(body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusCreated, httpResp.StatusCode)
+	assert.Equal(t, "hk_test_123", hook.ID)
+	assert.Equal(t, body.Name, hook.Name)
+	assert.Equal(t, body.URL, hook.URL)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHooksService_Create_ValidationError(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	_, _, err := svc.Create(blnkgo.CreateHookRequest{
+		Name:       "missing-url",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "url is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHooksService_Create_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	body := blnkgo.CreateHookRequest{
+		Name:       "Pre-transaction validation",
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	}
+
+	mockClient.On("NewRequest", "hooks", http.MethodPost, body).Return(nil, errors.New("failed to create request"))
+
+	hook, httpResp, err := svc.Create(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, hook)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -63,6 +63,7 @@ go test -tags=integration -v ./integration/...
 | #58 create api key | 0.14.x+ | POST /api-keys; master or api-keys:write key |
 | #59 list api keys | 0.14.x+ | GET /api-keys?owner=; master requires owner |
 | #60 delete api key | 0.14.x+ | DELETE /api-keys/{id}?owner=; master requires owner |
-| 0.15-only features (delete identity, hooks, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
+| #50 create hook | 0.8.4+ | POST /hooks; master key required |
+| 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue50_test.go
+++ b/integration/issue50_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+// Integration tests for issue #50 — Hooks.Create (POST /hooks).
+// Requires Blnk Core running at http://localhost:5001 with the master key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue50
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue50_CreateHook(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	hook, resp, err := client.Hooks.Create(blnkgo.CreateHookRequest{
+		Name:       fmt.Sprintf("issue50-hook-%d", time.Now().UnixNano()),
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotNil(t, hook)
+	require.NotEmpty(t, hook.ID)
+	require.Equal(t, blnkgo.HookTypePreTransaction, hook.Type)
+	require.Equal(t, "https://api.example.com/validate", hook.URL)
+	require.True(t, hook.Active)
+	require.Equal(t, 30, hook.Timeout)
+	require.Equal(t, 3, hook.RetryCount)
+	require.NotEmpty(t, hook.CreatedAt)
+}
+
+func TestIssue50_CreateHook_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Hooks.Create(blnkgo.CreateHookRequest{
+		Name:       "invalid-hook",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "url is required")
+}

--- a/validate_hook.go
+++ b/validate_hook.go
@@ -1,0 +1,35 @@
+package blnkgo
+
+import (
+	"fmt"
+	"strings"
+)
+
+func isValidHookType(t HookType) bool {
+	switch t {
+	case HookTypePreTransaction, HookTypePostTransaction:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateCreateHookRequest performs client-side checks before POST /hooks.
+func ValidateCreateHookRequest(body CreateHookRequest) error {
+	if strings.TrimSpace(body.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	if strings.TrimSpace(body.URL) == "" {
+		return fmt.Errorf("url is required")
+	}
+	if !isValidHookType(body.Type) {
+		return fmt.Errorf("type must be PRE_TRANSACTION or POST_TRANSACTION")
+	}
+	if body.Timeout <= 0 {
+		return fmt.Errorf("timeout must be a positive number")
+	}
+	if body.RetryCount < 0 {
+		return fmt.Errorf("retry_count must be a non-negative number")
+	}
+	return nil
+}

--- a/validate_hook_test.go
+++ b/validate_hook_test.go
@@ -1,0 +1,26 @@
+package blnkgo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateCreateHookRequest(t *testing.T) {
+	valid := CreateHookRequest{
+		Name:       "Pre-transaction validation",
+		URL:        "https://api.example.com/validate",
+		Type:       HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	}
+
+	assert.NoError(t, ValidateCreateHookRequest(valid))
+	assert.Error(t, ValidateCreateHookRequest(CreateHookRequest{URL: valid.URL, Type: valid.Type, Active: true, Timeout: 30, RetryCount: 3}))
+	assert.Error(t, ValidateCreateHookRequest(CreateHookRequest{Name: valid.Name, Type: valid.Type, Active: true, Timeout: 30, RetryCount: 3}))
+	assert.Error(t, ValidateCreateHookRequest(CreateHookRequest{Name: valid.Name, URL: valid.URL, Active: true, Timeout: 30, RetryCount: 3}))
+	assert.Error(t, ValidateCreateHookRequest(CreateHookRequest{Name: valid.Name, URL: valid.URL, Type: "INVALID", Active: true, Timeout: 30, RetryCount: 3}))
+	assert.Error(t, ValidateCreateHookRequest(CreateHookRequest{Name: valid.Name, URL: valid.URL, Type: valid.Type, Active: true, Timeout: 0, RetryCount: 3}))
+	assert.Error(t, ValidateCreateHookRequest(CreateHookRequest{Name: valid.Name, URL: valid.URL, Type: valid.Type, Active: true, Timeout: 30, RetryCount: -1}))
+}


### PR DESCRIPTION
## Summary
- Add `HooksService.Create()` calling `POST /hooks`
- Add `CreateHookRequest`, `HookResponse`, and `HookType` constants
- Add client-side validation aligned with TS SDK rules
- Register `Hooks` on `NewClient`
- Add unit tests and integration tests (`integration/issue50_test.go`)
- Document usage in README

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue50` against local Core
- [x] Postman: `TEST — #50 Create hook (run this folder only)` — expect 201 with `id`