### PR TITLE
Add Hooks.Update for PUT /hooks/{id} (closes #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,23 @@ if err != nil {
 fmt.Println("Hook ID:", hook.ID)
 ```
 
+Update an existing hook by ID:
+
+```go
+updated, resp, err := client.Hooks.Update(hook.ID, blnkgo.UpdateHookRequest{
+    Name:       "Pre-transaction validation (updated)",
+    URL:        "https://api.example.com/validate-v2",
+    Type:       blnkgo.HookTypePreTransaction,
+    Active:     false,
+    Timeout:    45,
+    RetryCount: 5,
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Updated hook:", updated.Name)
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/hooks.go
+++ b/hooks.go
@@ -1,6 +1,9 @@
 package blnkgo
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 type HooksService service
 
@@ -21,6 +24,9 @@ type CreateHookRequest struct {
 	Timeout    int      `json:"timeout"`
 	RetryCount int      `json:"retry_count"`
 }
+
+// UpdateHookRequest is the body for PUT /hooks/{id}.
+type UpdateHookRequest = CreateHookRequest
 
 // HookResponse is returned when a hook is created, listed, fetched, or updated.
 type HookResponse struct {
@@ -43,6 +49,26 @@ func (s *HooksService) Create(body CreateHookRequest) (*HookResponse, *http.Resp
 	}
 
 	req, err := s.client.NewRequest("hooks", http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hookResp := new(HookResponse)
+	resp, err := s.client.CallWithRetry(req, hookResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hookResp, resp, nil
+}
+
+// Update modifies an existing webhook by ID (master key required).
+func (s *HooksService) Update(hookID string, body UpdateHookRequest) (*HookResponse, *http.Response, error) {
+	if err := ValidateUpdateHookRequest(hookID, body); err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(fmt.Sprintf("hooks/%s", hookID), http.MethodPut, body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -93,3 +93,84 @@ func TestHooksService_Create_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestHooksService_Update_Success(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	hookID := "hk_test_123"
+	body := blnkgo.UpdateHookRequest{
+		Name:       "Pre-transaction validation (updated)",
+		URL:        "https://api.example.com/validate-v2",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     false,
+		Timeout:    45,
+		RetryCount: 5,
+	}
+
+	mockClient.On("NewRequest", "hooks/"+hookID, http.MethodPut, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.HookResponse)
+		*resp = blnkgo.HookResponse{
+			ID:          hookID,
+			Name:        body.Name,
+			URL:         body.URL,
+			Type:        body.Type,
+			Active:      body.Active,
+			Timeout:     body.Timeout,
+			RetryCount:  body.RetryCount,
+			CreatedAt:   "2024-11-26T08:36:36.238244338Z",
+			LastRun:     "0001-01-01T00:00:00Z",
+			LastSuccess: false,
+		}
+	})
+
+	hook, httpResp, err := svc.Update(hookID, body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, hookID, hook.ID)
+	assert.Equal(t, body.Name, hook.Name)
+	assert.False(t, hook.Active)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHooksService_Update_ValidationError(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	_, _, err := svc.Update("", blnkgo.UpdateHookRequest{
+		Name:       "updated",
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hook id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHooksService_Update_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	hookID := "hk_test_123"
+	body := blnkgo.UpdateHookRequest{
+		Name:       "Pre-transaction validation (updated)",
+		URL:        "https://api.example.com/validate-v2",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     false,
+		Timeout:    45,
+		RetryCount: 5,
+	}
+
+	mockClient.On("NewRequest", "hooks/"+hookID, http.MethodPut, body).Return(nil, errors.New("failed to create request"))
+
+	hook, httpResp, err := svc.Update(hookID, body)
+
+	assert.Error(t, err)
+	assert.Nil(t, hook)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -64,6 +64,7 @@ go test -tags=integration -v ./integration/...
 | #59 list api keys | 0.14.x+ | GET /api-keys?owner=; master requires owner |
 | #60 delete api key | 0.14.x+ | DELETE /api-keys/{id}?owner=; master requires owner |
 | #50 create hook | 0.8.4+ | POST /hooks; master key required |
+| #51 update hook | 0.8.4+ | PUT /hooks/{id}; master key required |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue51_test.go
+++ b/integration/issue51_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+// Integration tests for issue #51 — Hooks.Update (PUT /hooks/{id}).
+// Requires Blnk Core running at http://localhost:5001 with the master key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue51
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue51_UpdateHook(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	created, createResp, err := client.Hooks.Create(blnkgo.CreateHookRequest{
+		Name:       fmt.Sprintf("issue51-hook-%d", time.Now().UnixNano()),
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	require.NotEmpty(t, created.ID)
+
+	updatedName := fmt.Sprintf("issue51-updated-%d", time.Now().UnixNano())
+	updated, updateResp, err := client.Hooks.Update(created.ID, blnkgo.UpdateHookRequest{
+		Name:       updatedName,
+		URL:        "https://api.example.com/validate-v2",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     false,
+		Timeout:    45,
+		RetryCount: 5,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updateResp)
+	require.Equal(t, http.StatusOK, updateResp.StatusCode)
+	require.Equal(t, created.ID, updated.ID)
+	require.Equal(t, updatedName, updated.Name)
+	require.Equal(t, "https://api.example.com/validate-v2", updated.URL)
+	require.False(t, updated.Active)
+	require.Equal(t, 45, updated.Timeout)
+	require.Equal(t, 5, updated.RetryCount)
+}
+
+func TestIssue51_UpdateHook_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Hooks.Update("", blnkgo.UpdateHookRequest{
+		Name:       "updated",
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "hook id is required")
+}
+
+func TestIssue51_UpdateHook_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Hooks.Update("hk_nonexistent_issue51", blnkgo.UpdateHookRequest{
+		Name:       "updated",
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}

--- a/validate_hook.go
+++ b/validate_hook.go
@@ -33,3 +33,11 @@ func ValidateCreateHookRequest(body CreateHookRequest) error {
 	}
 	return nil
 }
+
+// ValidateUpdateHookRequest performs client-side checks before PUT /hooks/{id}.
+func ValidateUpdateHookRequest(hookID string, body UpdateHookRequest) error {
+	if strings.TrimSpace(hookID) == "" {
+		return fmt.Errorf("hook id is required")
+	}
+	return ValidateCreateHookRequest(body)
+}

--- a/validate_hook_test.go
+++ b/validate_hook_test.go
@@ -24,3 +24,19 @@ func TestValidateCreateHookRequest(t *testing.T) {
 	assert.Error(t, ValidateCreateHookRequest(CreateHookRequest{Name: valid.Name, URL: valid.URL, Type: valid.Type, Active: true, Timeout: 0, RetryCount: 3}))
 	assert.Error(t, ValidateCreateHookRequest(CreateHookRequest{Name: valid.Name, URL: valid.URL, Type: valid.Type, Active: true, Timeout: 30, RetryCount: -1}))
 }
+
+func TestValidateUpdateHookRequest(t *testing.T) {
+	valid := CreateHookRequest{
+		Name:       "Pre-transaction validation",
+		URL:        "https://api.example.com/validate",
+		Type:       HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	}
+
+	assert.NoError(t, ValidateUpdateHookRequest("hk_test_123", valid))
+	assert.Error(t, ValidateUpdateHookRequest("", valid))
+	assert.Error(t, ValidateUpdateHookRequest("   ", valid))
+	assert.Error(t, ValidateUpdateHookRequest("hk_test_123", CreateHookRequest{Name: valid.Name, Type: valid.Type, Active: true, Timeout: 30, RetryCount: 3}))
+}


### PR DESCRIPTION
## Summary
- Add `HooksService.Update()` calling `PUT /hooks/{id}`
- Add `UpdateHookRequest` type alias and `ValidateUpdateHookRequest`
- Add unit tests and integration tests (`integration/issue51_test.go`)
- Document usage in README

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue51` against local Core
- [x] Postman: `TEST — #51 Update hook (run this folder only)` — setup create (201), then update (200)