### PR TITLE
Add Hooks.Get for GET /hooks/{id} (closes #52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,6 +887,16 @@ if err != nil {
 fmt.Println("Updated hook:", updated.Name)
 ```
 
+View a hook by ID:
+
+```go
+hook, resp, err := client.Hooks.Get("hk_test_123")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Hook:", hook.Name, hook.Active)
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/hooks.go
+++ b/hooks.go
@@ -82,6 +82,26 @@ func (s *HooksService) Update(hookID string, body UpdateHookRequest) (*HookRespo
 	return hookResp, resp, nil
 }
 
+// Get retrieves a webhook by ID (master key required).
+func (s *HooksService) Get(hookID string) (*HookResponse, *http.Response, error) {
+	if err := ValidateHookID(hookID); err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(fmt.Sprintf("hooks/%s", hookID), http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hookResp := new(HookResponse)
+	resp, err := s.client.CallWithRetry(req, hookResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hookResp, resp, nil
+}
+
 func NewHooksService(client ClientInterface) *HooksService {
 	return &HooksService{client: client}
 }

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -174,3 +174,57 @@ func TestHooksService_Update_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestHooksService_Get_Success(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	hookID := "hk_test_123"
+	mockClient.On("NewRequest", "hooks/"+hookID, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.HookResponse)
+		*resp = blnkgo.HookResponse{
+			ID:          hookID,
+			Name:        "Pre-transaction validation",
+			URL:         "https://api.example.com/validate",
+			Type:        blnkgo.HookTypePreTransaction,
+			Active:      true,
+			Timeout:     30,
+			RetryCount:  3,
+			CreatedAt:   "2024-11-26T08:36:36.238244338Z",
+			LastRun:     "0001-01-01T00:00:00Z",
+			LastSuccess: false,
+		}
+	})
+
+	hook, httpResp, err := svc.Get(hookID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, hookID, hook.ID)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHooksService_Get_ValidationError(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	_, _, err := svc.Get("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hook id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHooksService_Get_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	hookID := "hk_test_123"
+	mockClient.On("NewRequest", "hooks/"+hookID, http.MethodGet, nil).Return(nil, errors.New("failed to create request"))
+
+	hook, httpResp, err := svc.Get(hookID)
+
+	assert.Error(t, err)
+	assert.Nil(t, hook)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -65,6 +65,7 @@ go test -tags=integration -v ./integration/...
 | #60 delete api key | 0.14.x+ | DELETE /api-keys/{id}?owner=; master requires owner |
 | #50 create hook | 0.8.4+ | POST /hooks; master key required |
 | #51 update hook | 0.8.4+ | PUT /hooks/{id}; master key required |
+| #52 get hook | 0.8.4+ | GET /hooks/{id}; master key required |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue52_test.go
+++ b/integration/issue52_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+// Integration tests for issue #52 — Hooks.Get (GET /hooks/{id}).
+// Requires Blnk Core running at http://localhost:5001 with the master key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue52
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue52_GetHook(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	created, createResp, err := client.Hooks.Create(blnkgo.CreateHookRequest{
+		Name:       fmt.Sprintf("issue52-hook-%d", time.Now().UnixNano()),
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	require.NotEmpty(t, created.ID)
+
+	hook, getResp, err := client.Hooks.Get(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, getResp)
+	require.Equal(t, http.StatusOK, getResp.StatusCode)
+	require.Equal(t, created.ID, hook.ID)
+	require.Equal(t, created.Name, hook.Name)
+	require.Equal(t, created.URL, hook.URL)
+	require.Equal(t, created.Type, hook.Type)
+	require.Equal(t, created.Active, hook.Active)
+	require.Equal(t, created.Timeout, hook.Timeout)
+	require.Equal(t, created.RetryCount, hook.RetryCount)
+}
+
+func TestIssue52_GetHook_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Hooks.Get("")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "hook id is required")
+}
+
+func TestIssue52_GetHook_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Hooks.Get("hk_nonexistent_issue52")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}

--- a/validate_hook.go
+++ b/validate_hook.go
@@ -36,8 +36,16 @@ func ValidateCreateHookRequest(body CreateHookRequest) error {
 
 // ValidateUpdateHookRequest performs client-side checks before PUT /hooks/{id}.
 func ValidateUpdateHookRequest(hookID string, body UpdateHookRequest) error {
+	if err := ValidateHookID(hookID); err != nil {
+		return err
+	}
+	return ValidateCreateHookRequest(body)
+}
+
+// ValidateHookID performs client-side checks before hook operations that require an ID.
+func ValidateHookID(hookID string) error {
 	if strings.TrimSpace(hookID) == "" {
 		return fmt.Errorf("hook id is required")
 	}
-	return ValidateCreateHookRequest(body)
+	return nil
 }

--- a/validate_hook_test.go
+++ b/validate_hook_test.go
@@ -40,3 +40,9 @@ func TestValidateUpdateHookRequest(t *testing.T) {
 	assert.Error(t, ValidateUpdateHookRequest("   ", valid))
 	assert.Error(t, ValidateUpdateHookRequest("hk_test_123", CreateHookRequest{Name: valid.Name, Type: valid.Type, Active: true, Timeout: 30, RetryCount: 3}))
 }
+
+func TestValidateHookID(t *testing.T) {
+	assert.NoError(t, ValidateHookID("hk_test_123"))
+	assert.Error(t, ValidateHookID(""))
+	assert.Error(t, ValidateHookID("   "))
+}


### PR DESCRIPTION
## Summary
- Add `HooksService.Get()` calling `GET /hooks/{id}`
- Add `ValidateHookID` shared with Update validation
- Add unit tests and integration tests (`integration/issue52_test.go`)
- Document usage in README

## Postman fixes (#51)
- Reordered `TEST — #51 Update hook` folder so setup POST runs before PUT
- Strengthened setup test to assert `issue51_hook_id` collection variable is saved

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue52` against local Core
- [x] Postman: `TEST — #52 Get hook (run this folder only)` — setup create (201), then get (200)
- [x] Postman: re-run `TEST — #51 Update hook` folder after order fix