### PR TITLE
Add Hooks.List for GET /hooks (closes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,20 @@ if err != nil {
 fmt.Println("Hook:", hook.Name, hook.Active)
 ```
 
+List hooks, optionally filtered by type:
+
+```go
+hooks, resp, err := client.Hooks.List(&blnkgo.ListHooksOptions{
+    Type: blnkgo.HookTypePreTransaction,
+})
+if err != nil {
+    log.Fatal(err)
+}
+for _, hook := range hooks {
+    fmt.Println(hook.ID, hook.Name, hook.Type)
+}
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/hooks.go
+++ b/hooks.go
@@ -102,6 +102,36 @@ func (s *HooksService) Get(hookID string) (*HookResponse, *http.Response, error)
 	return hookResp, resp, nil
 }
 
+// ListHooksOptions filters GET /hooks results.
+type ListHooksOptions struct {
+	Type HookType `url:"type,omitempty"`
+}
+
+// List returns webhooks, optionally filtered by type (master key required).
+func (s *HooksService) List(options *ListHooksOptions) ([]HookResponse, *http.Response, error) {
+	if err := ValidateListHooksOptions(options); err != nil {
+		return nil, nil, err
+	}
+
+	var query interface{}
+	if options != nil && options.Type != "" {
+		query = options
+	}
+
+	req, err := s.client.NewRequest("hooks", http.MethodGet, query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var hooks []HookResponse
+	resp, err := s.client.CallWithRetry(req, &hooks)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hooks, resp, nil
+}
+
 func NewHooksService(client ClientInterface) *HooksService {
 	return &HooksService{client: client}
 }

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -228,3 +228,77 @@ func TestHooksService_Get_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestHooksService_List_Success(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	opts := &blnkgo.ListHooksOptions{Type: blnkgo.HookTypePreTransaction}
+	mockClient.On("NewRequest", "hooks", http.MethodGet, opts).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		hooks := args.Get(1).(*[]blnkgo.HookResponse)
+		*hooks = []blnkgo.HookResponse{
+			{
+				ID:          "hook_test_123",
+				Name:        "Pre-transaction validation",
+				URL:         "https://api.example.com/validate",
+				Type:        blnkgo.HookTypePreTransaction,
+				Active:      true,
+				Timeout:     30,
+				RetryCount:  3,
+				CreatedAt:   "2024-11-26T08:36:36.238244338Z",
+				LastRun:     "0001-01-01T00:00:00Z",
+				LastSuccess: false,
+			},
+		}
+	})
+
+	hooks, httpResp, err := svc.List(opts)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Len(t, hooks, 1)
+	assert.Equal(t, "hook_test_123", hooks[0].ID)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHooksService_List_WithoutOptions(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	mockClient.On("NewRequest", "hooks", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		hooks := args.Get(1).(*[]blnkgo.HookResponse)
+		*hooks = []blnkgo.HookResponse{}
+	})
+
+	hooks, httpResp, err := svc.List(nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Empty(t, hooks)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHooksService_List_ValidationError(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	_, _, err := svc.List(&blnkgo.ListHooksOptions{Type: "INVALID"})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "type must be PRE_TRANSACTION or POST_TRANSACTION")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHooksService_List_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	opts := &blnkgo.ListHooksOptions{Type: blnkgo.HookTypePreTransaction}
+	mockClient.On("NewRequest", "hooks", http.MethodGet, opts).Return(nil, errors.New("failed to create request"))
+
+	hooks, httpResp, err := svc.List(opts)
+
+	assert.Error(t, err)
+	assert.Nil(t, hooks)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -66,6 +66,7 @@ go test -tags=integration -v ./integration/...
 | #50 create hook | 0.8.4+ | POST /hooks; master key required |
 | #51 update hook | 0.8.4+ | PUT /hooks/{id}; master key required |
 | #52 get hook | 0.8.4+ | GET /hooks/{id}; master key required |
+| #53 list hooks | 0.8.4+ | GET /hooks?type=; master key required |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue53_test.go
+++ b/integration/issue53_test.go
@@ -1,0 +1,67 @@
+//go:build integration
+
+// Integration tests for issue #53 — Hooks.List (GET /hooks).
+// Requires Blnk Core running at http://localhost:5001 with the master key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue53
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue53_ListHooks(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	created, createResp, err := client.Hooks.Create(blnkgo.CreateHookRequest{
+		Name:       fmt.Sprintf("issue53-hook-%d", time.Now().UnixNano()),
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	require.NotEmpty(t, created.ID)
+
+	hooks, listResp, err := client.Hooks.List(&blnkgo.ListHooksOptions{Type: blnkgo.HookTypePreTransaction})
+	require.NoError(t, err)
+	require.NotNil(t, listResp)
+	require.Equal(t, http.StatusOK, listResp.StatusCode)
+
+	found := false
+	for _, hook := range hooks {
+		if hook.ID == created.ID {
+			found = true
+			require.Equal(t, created.Name, hook.Name)
+			require.Equal(t, blnkgo.HookTypePreTransaction, hook.Type)
+			break
+		}
+	}
+	require.True(t, found, "expected created hook in list response")
+}
+
+func TestIssue53_ListHooks_WithoutOptions(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	hooks, resp, err := client.Hooks.List(nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, hooks)
+}
+
+func TestIssue53_ListHooks_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Hooks.List(&blnkgo.ListHooksOptions{Type: "INVALID"})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "type must be PRE_TRANSACTION or POST_TRANSACTION")
+}

--- a/validate_hook.go
+++ b/validate_hook.go
@@ -49,3 +49,14 @@ func ValidateHookID(hookID string) error {
 	}
 	return nil
 }
+
+// ValidateListHooksOptions performs client-side checks before GET /hooks.
+func ValidateListHooksOptions(options *ListHooksOptions) error {
+	if options == nil {
+		return nil
+	}
+	if options.Type != "" && !isValidHookType(options.Type) {
+		return fmt.Errorf("type must be PRE_TRANSACTION or POST_TRANSACTION")
+	}
+	return nil
+}

--- a/validate_hook_test.go
+++ b/validate_hook_test.go
@@ -46,3 +46,10 @@ func TestValidateHookID(t *testing.T) {
 	assert.Error(t, ValidateHookID(""))
 	assert.Error(t, ValidateHookID("   "))
 }
+
+func TestValidateListHooksOptions(t *testing.T) {
+	assert.NoError(t, ValidateListHooksOptions(nil))
+	assert.NoError(t, ValidateListHooksOptions(&ListHooksOptions{}))
+	assert.NoError(t, ValidateListHooksOptions(&ListHooksOptions{Type: HookTypePreTransaction}))
+	assert.Error(t, ValidateListHooksOptions(&ListHooksOptions{Type: "INVALID"}))
+}


### PR DESCRIPTION
## Summary
- Add `HooksService.List()` calling `GET /hooks` with optional `type` query filter
- Add `ListHooksOptions` and `ValidateListHooksOptions`
- Add unit tests and integration tests (`integration/issue53_test.go`)
- Document usage in README

## Postman
- Added `TEST — #53 List hooks (run this folder only)` — setup create (201), then list by type (200)
- Fixed `#51 Update hook` PUT request with pre-request guard when `issue51_hook_id` is unset
- Restored full collection variables including `issue53_hook_id`

**Important:** Run the **folder only**, in order (request 1 then 2). Do not run request 2 alone.

## Test plan
- [x] `go test ./...`
- [x] `go test -tags=integration -run Issue53` against local Core
- [x] Manual curl: POST create → GET `?type=PRE_TRANSACTION` finds hook