### PR TITLE
Add Hooks.Delete for DELETE /hooks/{id} (closes #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,16 @@ for _, hook := range hooks {
 }
 ```
 
+Delete a hook by ID:
+
+```go
+deleted, resp, err := client.Hooks.Delete("hook_test_123")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(deleted.Message) // hook deleted successfully
+```
+
 ### Search
 
 Search across ledgers, balances, and transactions with flexible query parameters.

--- a/hooks.go
+++ b/hooks.go
@@ -42,6 +42,11 @@ type HookResponse struct {
 	LastSuccess bool     `json:"last_success"`
 }
 
+// DeleteHookResponse is returned when a hook is deleted.
+type DeleteHookResponse struct {
+	Message string `json:"message"`
+}
+
 // Create registers a new webhook (master key required).
 func (s *HooksService) Create(body CreateHookRequest) (*HookResponse, *http.Response, error) {
 	if err := ValidateCreateHookRequest(body); err != nil {
@@ -130,6 +135,26 @@ func (s *HooksService) List(options *ListHooksOptions) ([]HookResponse, *http.Re
 	}
 
 	return hooks, resp, nil
+}
+
+// Delete removes a webhook by ID (master key required).
+func (s *HooksService) Delete(hookID string) (*DeleteHookResponse, *http.Response, error) {
+	if err := ValidateHookID(hookID); err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(fmt.Sprintf("hooks/%s", hookID), http.MethodDelete, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deleteResp := new(DeleteHookResponse)
+	resp, err := s.client.CallWithRetry(req, deleteResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return deleteResp, resp, nil
 }
 
 func NewHooksService(client ClientInterface) *HooksService {

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -302,3 +302,46 @@ func TestHooksService_List_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestHooksService_Delete_Success(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	hookID := "hook_test_123"
+	mockClient.On("NewRequest", "hooks/"+hookID, http.MethodDelete, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.DeleteHookResponse)
+		*resp = blnkgo.DeleteHookResponse{Message: "hook deleted successfully"}
+	})
+
+	deleted, httpResp, err := svc.Delete(hookID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "hook deleted successfully", deleted.Message)
+	mockClient.AssertExpectations(t)
+}
+
+func TestHooksService_Delete_ValidationError(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	_, _, err := svc.Delete("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hook id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHooksService_Delete_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupHooksService()
+
+	hookID := "hook_test_123"
+	mockClient.On("NewRequest", "hooks/"+hookID, http.MethodDelete, nil).Return(nil, errors.New("failed to create request"))
+
+	deleted, httpResp, err := svc.Delete(hookID)
+
+	assert.Error(t, err)
+	assert.Nil(t, deleted)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -67,6 +67,7 @@ go test -tags=integration -v ./integration/...
 | #51 update hook | 0.8.4+ | PUT /hooks/{id}; master key required |
 | #52 get hook | 0.8.4+ | GET /hooks/{id}; master key required |
 | #53 list hooks | 0.8.4+ | GET /hooks?type=; master key required |
+| #54 delete hook | 0.8.4+ | DELETE /hooks/{id}; master key required |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue54_test.go
+++ b/integration/issue54_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+
+// Integration tests for issue #54 — Hooks.Delete (DELETE /hooks/{id}).
+// Requires Blnk Core running at http://localhost:5001 with the master key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue54
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue54_DeleteHook(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	created, createResp, err := client.Hooks.Create(blnkgo.CreateHookRequest{
+		Name:       fmt.Sprintf("issue54-hook-%d", time.Now().UnixNano()),
+		URL:        "https://api.example.com/validate",
+		Type:       blnkgo.HookTypePreTransaction,
+		Active:     true,
+		Timeout:    30,
+		RetryCount: 3,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	require.NotEmpty(t, created.ID)
+
+	deleted, deleteResp, err := client.Hooks.Delete(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, deleteResp)
+	require.Equal(t, http.StatusOK, deleteResp.StatusCode)
+	require.Equal(t, "hook deleted successfully", deleted.Message)
+
+	_, getResp, err := client.Hooks.Get(created.ID)
+	require.Error(t, err)
+	require.NotNil(t, getResp)
+	require.NotEqual(t, http.StatusOK, getResp.StatusCode)
+}
+
+func TestIssue54_DeleteHook_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Hooks.Delete("")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "hook id is required")
+}
+
+func TestIssue54_DeleteHook_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Hooks.Delete("hook_nonexistent_issue54")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary
- Adds `Hooks.Delete(hookID)` calling `DELETE /hooks/{id}` with `DeleteHookResponse{ message }`
- Reuses `ValidateHookID` for client-side validation
- Unit tests (success, validation, request creation failure) and integration tests (delete, not-found, validation)
- README example and integration README entry

## Test plan
- [x] `go test ./... -run TestHooksService_Delete`
- [x] `BLNK_API_KEY=blnk-local-dev-secret-change-me go test -tags=integration -v ./integration/... -run Issue54`
- [x] Postman folder **TEST — #54 Delete hook (run this folder only)** — run folder (POST setup → DELETE)