### PR TITLE
Add Search reindex methods (closes #56, #57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,6 +942,24 @@ balances, resp, err := client.Search.SearchBalances(searchParams)
 ledgers, resp, err := client.Search.SearchLedgers(searchParams)
 ```
 
+Start a Typesense reindex and poll progress:
+
+```go
+started, resp, err := client.Search.StartReindex(&blnkgo.StartReindexRequest{
+    BatchSize: intPtr(1000),
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(started.Message, started.Progress.Status)
+
+progress, resp, err := client.Search.GetReindexStatus()
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(progress.Status, progress.Phase, progress.ProcessedRecords, progress.TotalRecords)
+```
+
 ---
 
 ## 8. Examples

--- a/integration/README.md
+++ b/integration/README.md
@@ -68,6 +68,8 @@ go test -tags=integration -v ./integration/...
 | #52 get hook | 0.8.4+ | GET /hooks/{id}; master key required |
 | #53 list hooks | 0.8.4+ | GET /hooks?type=; master key required |
 | #54 delete hook | 0.8.4+ | DELETE /hooks/{id}; master key required |
+| #56 start reindex | 0.13.2+ | POST /search/reindex |
+| #57 get reindex status | 0.13.2+ | GET /search/reindex |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue56_test.go
+++ b/integration/issue56_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+// Integration tests for issue #56 — Search.StartReindex (POST /search/reindex).
+// Requires Blnk Core running at http://localhost:5001 with the master key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue56
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestIssue56_StartReindex(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	started, resp, err := client.Search.StartReindex(nil)
+	if err != nil && resp != nil && resp.StatusCode == http.StatusConflict {
+		t.Skip("reindex already in progress on local Core")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.Equal(t, "Reindex operation started", started.Message)
+	require.NotEmpty(t, started.Progress.Status)
+}
+
+func TestIssue56_StartReindex_WithBatchSize(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	started, resp, err := client.Search.StartReindex(&blnkgo.StartReindexRequest{BatchSize: intPtr(500)})
+	if err != nil && resp != nil && resp.StatusCode == http.StatusConflict {
+		t.Skip("reindex already in progress on local Core")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.Equal(t, "Reindex operation started", started.Message)
+}
+
+func TestIssue56_StartReindex_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Search.StartReindex(&blnkgo.StartReindexRequest{BatchSize: intPtr(0)})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "batch_size must be a positive integer")
+}

--- a/integration/issue57_test.go
+++ b/integration/issue57_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+// Integration tests for issue #57 — Search.GetReindexStatus (GET /search/reindex).
+// Requires Blnk Core running at http://localhost:5001 with the master key.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue57
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue57_GetReindexStatus(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	// Ensure a reindex has been started (may already be running from a prior test).
+	_, startResp, err := client.Search.StartReindex(nil)
+	if err != nil && startResp != nil && startResp.StatusCode == http.StatusConflict {
+		// already in progress — fine for status check
+	} else {
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, startResp.StatusCode)
+	}
+
+	progress, resp, err := client.Search.GetReindexStatus()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, progress.Status)
+}
+
+func TestIssue57_GetReindexStatus_AfterStart(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, _, _ = client.Search.StartReindex(&blnkgo.StartReindexRequest{BatchSize: intPtr(1000)})
+
+	progress, resp, err := client.Search.GetReindexStatus()
+	if err != nil && resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Skip("no reindex operation started on local Core")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, progress.Status)
+}

--- a/search.go
+++ b/search.go
@@ -135,6 +135,28 @@ type SearchDocument struct {
 	Name string `json:"name,omitempty"`
 }
 
+// StartReindexRequest is the optional body for POST /search/reindex.
+type StartReindexRequest struct {
+	BatchSize *int `json:"batch_size,omitempty"`
+}
+
+// ReindexProgress tracks Typesense reindex progress.
+type ReindexProgress struct {
+	Status           string     `json:"status"`
+	Phase            string     `json:"phase"`
+	TotalRecords     int64      `json:"total_records"`
+	ProcessedRecords int64      `json:"processed_records"`
+	Errors           []string   `json:"errors,omitempty"`
+	StartedAt        time.Time  `json:"started_at"`
+	CompletedAt      *time.Time `json:"completed_at,omitempty"`
+}
+
+// StartReindexResponse is returned when a reindex job is started.
+type StartReindexResponse struct {
+	Message  string          `json:"message"`
+	Progress ReindexProgress `json:"progress"`
+}
+
 func (s *SearchService) SearchDocument(body SearchParams, resource ResourceType) (*SearchResponse, *http.Response, error) {
 	u := fmt.Sprintf("search/%s", resource)
 	req, err := s.client.NewRequest(u, http.MethodPost, body)
@@ -149,6 +171,49 @@ func (s *SearchService) SearchDocument(body SearchParams, resource ResourceType)
 	}
 
 	return searchResponse, resp, nil
+}
+
+// StartReindex triggers a full Typesense reindex from the database.
+func (s *SearchService) StartReindex(options *StartReindexRequest) (*StartReindexResponse, *http.Response, error) {
+	if options != nil {
+		if err := ValidateStartReindexRequest(*options); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var body interface{} = struct{}{}
+	if options != nil && options.BatchSize != nil && *options.BatchSize > 0 {
+		body = StartReindexRequest{BatchSize: options.BatchSize}
+	}
+
+	req, err := s.client.NewRequest("search/reindex", http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	startResp := new(StartReindexResponse)
+	resp, err := s.client.CallWithRetry(req, startResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return startResp, resp, nil
+}
+
+// GetReindexStatus returns the current Typesense reindex progress.
+func (s *SearchService) GetReindexStatus() (*ReindexProgress, *http.Response, error) {
+	req, err := s.client.NewRequest("search/reindex", http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	progress := new(ReindexProgress)
+	resp, err := s.client.CallWithRetry(req, progress)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return progress, resp, nil
 }
 
 func NewSearchService(c ClientInterface) *SearchService {

--- a/search_test.go
+++ b/search_test.go
@@ -18,6 +18,10 @@ func setupSearchService() (*MockClient, *blnkgo.SearchService) {
 	return mockClient, svc
 }
 
+func intPtr(v int) *int {
+	return &v
+}
+
 func TestSearchService_SearchDocument_Success(t *testing.T) {
 	mockClient, svc := setupSearchService()
 
@@ -751,4 +755,108 @@ func TestSearchDocument_LedgerFields(t *testing.T) {
 	if metaStr, ok := doc.MetaData.(string); ok {
 		assert.Contains(t, metaStr, "motorista pontos")
 	}
+}
+
+func TestSearchService_StartReindex_SuccessEmptyBody(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	mockClient.On("NewRequest", "search/reindex", http.MethodPost, struct{}{}).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusAccepted}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.StartReindexResponse)
+		*resp = blnkgo.StartReindexResponse{
+			Message: "Reindex operation started",
+			Progress: blnkgo.ReindexProgress{
+				Status: "in_progress",
+				Phase:  "indexing_transactions",
+			},
+		}
+	})
+
+	started, httpResp, err := svc.StartReindex(nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusAccepted, httpResp.StatusCode)
+	assert.Equal(t, "Reindex operation started", started.Message)
+	assert.Equal(t, "in_progress", started.Progress.Status)
+	mockClient.AssertExpectations(t)
+}
+
+func TestSearchService_StartReindex_SuccessWithBatchSize(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	opts := &blnkgo.StartReindexRequest{BatchSize: intPtr(500)}
+	body := blnkgo.StartReindexRequest{BatchSize: intPtr(500)}
+
+	mockClient.On("NewRequest", "search/reindex", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusAccepted}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.StartReindexResponse)
+		*resp = blnkgo.StartReindexResponse{Message: "Reindex operation started"}
+	})
+
+	started, httpResp, err := svc.StartReindex(opts)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, started)
+	assert.Equal(t, http.StatusAccepted, httpResp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestSearchService_StartReindex_ValidationError(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	opts := &blnkgo.StartReindexRequest{BatchSize: intPtr(0)}
+	_, _, err := svc.StartReindex(opts)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "batch_size must be a positive integer")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestSearchService_StartReindex_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	mockClient.On("NewRequest", "search/reindex", http.MethodPost, struct{}{}).Return(nil, fmt.Errorf("failed to create request"))
+
+	started, httpResp, err := svc.StartReindex(nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, started)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestSearchService_GetReindexStatus_Success(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	mockClient.On("NewRequest", "search/reindex", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.ReindexProgress)
+		*resp = blnkgo.ReindexProgress{
+			Status: "in_progress",
+			Phase:  "indexing_transactions",
+		}
+	})
+
+	progress, httpResp, err := svc.GetReindexStatus()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "in_progress", progress.Status)
+	assert.Equal(t, "indexing_transactions", progress.Phase)
+	mockClient.AssertExpectations(t)
+}
+
+func TestSearchService_GetReindexStatus_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	mockClient.On("NewRequest", "search/reindex", http.MethodGet, nil).Return(nil, fmt.Errorf("failed to create request"))
+
+	progress, httpResp, err := svc.GetReindexStatus()
+
+	assert.Error(t, err)
+	assert.Nil(t, progress)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
 }

--- a/validate_search.go
+++ b/validate_search.go
@@ -1,0 +1,11 @@
+package blnkgo
+
+import "fmt"
+
+// ValidateStartReindexRequest performs client-side checks before POST /search/reindex.
+func ValidateStartReindexRequest(body StartReindexRequest) error {
+	if body.BatchSize != nil && *body.BatchSize < 1 {
+		return fmt.Errorf("batch_size must be a positive integer if provided")
+	}
+	return nil
+}

--- a/validate_search_test.go
+++ b/validate_search_test.go
@@ -1,0 +1,22 @@
+package blnkgo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateStartReindexRequest(t *testing.T) {
+	assert.NoError(t, ValidateStartReindexRequest(StartReindexRequest{}))
+	batchSize := 1000
+	assert.NoError(t, ValidateStartReindexRequest(StartReindexRequest{BatchSize: &batchSize}))
+
+	zero := 0
+	err := ValidateStartReindexRequest(StartReindexRequest{BatchSize: &zero})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "batch_size must be a positive integer")
+
+	negative := -1
+	err = ValidateStartReindexRequest(StartReindexRequest{BatchSize: &negative})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Adds `Search.StartReindex` → `POST /search/reindex` with optional `batch_size`
- Adds `Search.GetReindexStatus` → `GET /search/reindex`
- Shared types: `StartReindexRequest`, `ReindexProgress`, `StartReindexResponse`
- Client-side validation rejects non-positive `batch_size` when explicitly set
- Unit + integration tests, README examples

## Test plan
- [x] `go test ./... -run 'TestSearchService_StartReindex|TestSearchService_GetReindexStatus|TestValidateStartReindexRequest'`
- [x] `BLNK_API_KEY=blnk-local-dev-secret-change-me go test -tags=integration -v ./integration/... -run 'Issue56|Issue57'`
- [x] Postman folders **TEST — #56 Start reindex** and **TEST — #57 Get reindex status** (run each folder only)