### PR TITLE
Add Identity.TokenizeField (closes #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,19 @@ if result.TotalCount != nil {
 fmt.Printf("Data: %+v\n", result.Data)
 ```
 
+Tokenize a single PII field (use PascalCase struct field names such as `FirstName`, not `first_name`):
+
+```go
+tokenized, resp, err := client.Identity.TokenizeField(
+    identity.IdentityId,
+    string(blnkgo.TokenizableFieldFirstName),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(tokenized.Message) // Field tokenized successfully
+```
+
 ### Reconciliation
 
 The reconciliation feature allows you to match and verify transactions against external data sources.

--- a/identity.go
+++ b/identity.go
@@ -35,6 +35,24 @@ type IdentityResponse struct {
 	Identity
 }
 
+// TokenizableIdentityField is a PascalCase Core struct field name (not snake_case JSON key).
+type TokenizableIdentityField string
+
+const (
+	TokenizableFieldFirstName    TokenizableIdentityField = "FirstName"
+	TokenizableFieldLastName     TokenizableIdentityField = "LastName"
+	TokenizableFieldOtherNames   TokenizableIdentityField = "OtherNames"
+	TokenizableFieldEmailAddress TokenizableIdentityField = "EmailAddress"
+	TokenizableFieldPhoneNumber  TokenizableIdentityField = "PhoneNumber"
+	TokenizableFieldStreet       TokenizableIdentityField = "Street"
+	TokenizableFieldPostCode     TokenizableIdentityField = "PostCode"
+)
+
+// TokenizeFieldResponse is returned when a single identity field is tokenized.
+type TokenizeFieldResponse struct {
+	Message string `json:"message"`
+}
+
 func (s *IdentityService) Create(identity Identity) (*IdentityResponse, *http.Response, error) {
 	//validate the identity
 	if err := ValidateCreateIdentity(identity); err != nil {
@@ -106,6 +124,27 @@ func (s *IdentityService) Filter(params FilterParams) (*FilterResponse, *http.Re
 	}
 
 	return &filterResponse, resp, nil
+}
+
+// TokenizeField tokenizes a single PII field on an identity.
+func (s *IdentityService) TokenizeField(identityID string, field string) (*TokenizeFieldResponse, *http.Response, error) {
+	if err := ValidateTokenizeIdentityField(identityID, field); err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("identities/%s/tokenize/%s", identityID, field)
+	req, err := s.client.NewRequest(u, http.MethodPost, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tokenizeResp := new(TokenizeFieldResponse)
+	resp, err := s.client.CallWithRetry(req, tokenizeResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tokenizeResp, resp, nil
 }
 
 func NewIdentityService(client ClientInterface) *IdentityService {

--- a/identity_test.go
+++ b/identity_test.go
@@ -484,3 +484,62 @@ func TestIdentityService_Filter_ServerError(t *testing.T) {
 	assert.Equal(t, expectedResp, resp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestIdentityService_TokenizeField_Success(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_573ebcc9-4da0-4295-82dc-0fb152b56660"
+	field := string(blnkgo.TokenizableFieldFirstName)
+	path := "identities/" + identityID + "/tokenize/" + field
+
+	mockClient.On("NewRequest", path, http.MethodPost, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.TokenizeFieldResponse)
+		*resp = blnkgo.TokenizeFieldResponse{Message: "Field tokenized successfully"}
+	})
+
+	tokenized, httpResp, err := svc.TokenizeField(identityID, field)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "Field tokenized successfully", tokenized.Message)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_TokenizeField_ValidationErrorEmptyID(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	_, _, err := svc.TokenizeField("", string(blnkgo.TokenizableFieldFirstName))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "identity id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_TokenizeField_ValidationErrorEmptyField(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	_, _, err := svc.TokenizeField("idt_test_123", "")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "field name is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_TokenizeField_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_test_123"
+	field := string(blnkgo.TokenizableFieldEmailAddress)
+	path := "identities/" + identityID + "/tokenize/" + field
+
+	mockClient.On("NewRequest", path, http.MethodPost, nil).Return(nil, errors.New("failed to create request"))
+
+	tokenized, httpResp, err := svc.TokenizeField(identityID, field)
+
+	assert.Error(t, err)
+	assert.Nil(t, tokenized)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -70,6 +70,7 @@ go test -tags=integration -v ./integration/...
 | #54 delete hook | 0.8.4+ | DELETE /hooks/{id}; master key required |
 | #56 start reindex | 0.13.2+ | POST /search/reindex |
 | #57 get reindex status | 0.13.2+ | GET /search/reindex |
+| #45 tokenize identity field | 0.13.2+ | POST /identities/{id}/tokenize/{field}; tokenization must be enabled |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue45_test.go
+++ b/integration/issue45_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+// Integration tests for issue #45 — Identity.TokenizeField (POST /identities/{id}/tokenize/{field}).
+// Requires Blnk Core running at http://localhost:5001 with tokenization enabled.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue45
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue45_TokenizeField(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	dob := time.Date(1990, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Tokenize",
+		LastName:     "Field",
+		EmailAddress: fmt.Sprintf("issue45-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+		DOB:          &dob,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	require.NotEmpty(t, created.IdentityId)
+
+	tokenized, tokenizeResp, err := client.Identity.TokenizeField(created.IdentityId, string(blnkgo.TokenizableFieldFirstName))
+	require.NoError(t, err)
+	require.NotNil(t, tokenizeResp)
+	require.Equal(t, http.StatusOK, tokenizeResp.StatusCode)
+	require.Equal(t, "Field tokenized successfully", tokenized.Message)
+}
+
+func TestIssue45_TokenizeField_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.TokenizeField("", string(blnkgo.TokenizableFieldFirstName))
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "identity id is required")
+}
+
+func TestIssue45_TokenizeField_AlreadyTokenized(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Already",
+		LastName:     "Tokenized",
+		EmailAddress: fmt.Sprintf("issue45-dup-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	_, firstResp, err := client.Identity.TokenizeField(created.IdentityId, string(blnkgo.TokenizableFieldLastName))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, firstResp.StatusCode)
+
+	_, secondResp, err := client.Identity.TokenizeField(created.IdentityId, string(blnkgo.TokenizableFieldLastName))
+	require.Error(t, err)
+	require.NotNil(t, secondResp)
+	require.NotEqual(t, http.StatusOK, secondResp.StatusCode)
+}

--- a/validate_identity.go
+++ b/validate_identity.go
@@ -30,3 +30,22 @@ func ValidateCreateIdentity(identity Identity) error {
 	}
 	return validateIdentityID(identity.IdentityID)
 }
+
+// ValidateIdentityID performs client-side checks before identity operations that require an ID.
+func ValidateIdentityID(identityID string) error {
+	if strings.TrimSpace(identityID) == "" {
+		return fmt.Errorf("identity id is required")
+	}
+	return nil
+}
+
+// ValidateTokenizeIdentityField performs client-side checks before POST /identities/{id}/tokenize/{field}.
+func ValidateTokenizeIdentityField(identityID, field string) error {
+	if err := ValidateIdentityID(identityID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(field) == "" {
+		return fmt.Errorf("field name is required")
+	}
+	return nil
+}

--- a/validate_identity_test.go
+++ b/validate_identity_test.go
@@ -99,3 +99,15 @@ func TestIdentity_Update_JSONMarshal_IncludesEmptyStrings(t *testing.T) {
 	require.Equal(t, "", decoded["post_code"])
 	require.Equal(t, "", decoded["city"])
 }
+
+func TestValidateIdentityID(t *testing.T) {
+	require.NoError(t, blnkgo.ValidateIdentityID("idt_test_123"))
+	require.Error(t, blnkgo.ValidateIdentityID(""))
+	require.Error(t, blnkgo.ValidateIdentityID("   "))
+}
+
+func TestValidateTokenizeIdentityField(t *testing.T) {
+	require.NoError(t, blnkgo.ValidateTokenizeIdentityField("idt_test_123", "FirstName"))
+	require.Error(t, blnkgo.ValidateTokenizeIdentityField("", "FirstName"))
+	require.Error(t, blnkgo.ValidateTokenizeIdentityField("idt_test_123", ""))
+}


### PR DESCRIPTION
## Summary
- Adds `Identity.TokenizeField(identityID, field)` → `POST /identities/{id}/tokenize/{field}`
- Adds `TokenizableIdentityField` constants (`FirstName`, `EmailAddress`, etc.) — PascalCase struct names, not snake_case JSON keys
- Adds `ValidateIdentityID` and `ValidateTokenizeIdentityField` for client-side validation
- Unit + integration tests, README example

> **Note:** #56 (`Search.StartReindex`) and #57 were already merged in PR #111.

## Test plan
- [x] `go test ./... -run 'TestIdentityService_TokenizeField|TestValidateIdentityID|TestValidateTokenizeIdentityField'`
- [x] `BLNK_API_KEY=blnk-local-dev-secret-change-me go test -tags=integration -v ./integration/... -run Issue45`
- [ ] Postman folder **TEST — #45 Tokenize identity field** (POST create identity → POST tokenize/FirstName)