### PR TITLE
Add Identity.Tokenize (closes #46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,22 @@ if err != nil {
 fmt.Println(tokenized.Message) // Field tokenized successfully
 ```
 
+Tokenize multiple PII fields in one request:
+
+```go
+tokenized, resp, err := client.Identity.Tokenize(identity.IdentityId, blnkgo.TokenizeRequest{
+    Fields: []blnkgo.TokenizableIdentityField{
+        blnkgo.TokenizableFieldFirstName,
+        blnkgo.TokenizableFieldLastName,
+        blnkgo.TokenizableFieldEmailAddress,
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(tokenized.Message) // Fields tokenized successfully
+```
+
 ### Reconciliation
 
 The reconciliation feature allows you to match and verify transactions against external data sources.

--- a/identity.go
+++ b/identity.go
@@ -53,6 +53,16 @@ type TokenizeFieldResponse struct {
 	Message string `json:"message"`
 }
 
+// TokenizeRequest is the body for POST /identities/{id}/tokenize.
+type TokenizeRequest struct {
+	Fields []TokenizableIdentityField `json:"fields"`
+}
+
+// TokenizeResponse is returned when multiple identity fields are tokenized.
+type TokenizeResponse struct {
+	Message string `json:"message"`
+}
+
 func (s *IdentityService) Create(identity Identity) (*IdentityResponse, *http.Response, error) {
 	//validate the identity
 	if err := ValidateCreateIdentity(identity); err != nil {
@@ -139,6 +149,27 @@ func (s *IdentityService) TokenizeField(identityID string, field string) (*Token
 	}
 
 	tokenizeResp := new(TokenizeFieldResponse)
+	resp, err := s.client.CallWithRetry(req, tokenizeResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tokenizeResp, resp, nil
+}
+
+// Tokenize tokenizes multiple PII fields on an identity.
+func (s *IdentityService) Tokenize(identityID string, body TokenizeRequest) (*TokenizeResponse, *http.Response, error) {
+	if err := ValidateTokenizeIdentityRequest(identityID, body); err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("identities/%s/tokenize", identityID)
+	req, err := s.client.NewRequest(u, http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tokenizeResp := new(TokenizeResponse)
 	resp, err := s.client.CallWithRetry(req, tokenizeResp)
 	if err != nil {
 		return nil, resp, err

--- a/identity_test.go
+++ b/identity_test.go
@@ -543,3 +543,68 @@ func TestIdentityService_TokenizeField_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestIdentityService_Tokenize_Success(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_573ebcc9-4da0-4295-82dc-0fb152b56660"
+	body := blnkgo.TokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{
+			blnkgo.TokenizableFieldFirstName,
+			blnkgo.TokenizableFieldLastName,
+		},
+	}
+	path := "identities/" + identityID + "/tokenize"
+
+	mockClient.On("NewRequest", path, http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.TokenizeResponse)
+		*resp = blnkgo.TokenizeResponse{Message: "Fields tokenized successfully"}
+	})
+
+	tokenized, httpResp, err := svc.Tokenize(identityID, body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "Fields tokenized successfully", tokenized.Message)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_Tokenize_ValidationErrorEmptyID(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	body := blnkgo.TokenizeRequest{Fields: []blnkgo.TokenizableIdentityField{blnkgo.TokenizableFieldFirstName}}
+	_, _, err := svc.Tokenize("", body)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "identity id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_Tokenize_ValidationErrorEmptyFields(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	_, _, err := svc.Tokenize("idt_test_123", blnkgo.TokenizeRequest{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one field must be specified")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_Tokenize_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_test_123"
+	body := blnkgo.TokenizeRequest{Fields: []blnkgo.TokenizableIdentityField{blnkgo.TokenizableFieldEmailAddress}}
+	path := "identities/" + identityID + "/tokenize"
+
+	mockClient.On("NewRequest", path, http.MethodPost, body).Return(nil, errors.New("failed to create request"))
+
+	tokenized, httpResp, err := svc.Tokenize(identityID, body)
+
+	assert.Error(t, err)
+	assert.Nil(t, tokenized)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -71,6 +71,7 @@ go test -tags=integration -v ./integration/...
 | #56 start reindex | 0.13.2+ | POST /search/reindex |
 | #57 get reindex status | 0.13.2+ | GET /search/reindex |
 | #45 tokenize identity field | 0.13.2+ | POST /identities/{id}/tokenize/{field}; tokenization must be enabled |
+| #46 tokenize identity | 0.13.2+ | POST /identities/{id}/tokenize; tokenization must be enabled |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue46_test.go
+++ b/integration/issue46_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+// Integration tests for issue #46 — Identity.Tokenize (POST /identities/{id}/tokenize).
+// Requires Blnk Core running at http://localhost:5001 with tokenization enabled.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue46
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue46_Tokenize(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Multi",
+		LastName:     "Tokenize",
+		EmailAddress: fmt.Sprintf("issue46-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	require.NotEmpty(t, created.IdentityId)
+
+	tokenized, tokenizeResp, err := client.Identity.Tokenize(created.IdentityId, blnkgo.TokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{
+			blnkgo.TokenizableFieldFirstName,
+			blnkgo.TokenizableFieldLastName,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tokenizeResp)
+	require.Equal(t, http.StatusOK, tokenizeResp.StatusCode)
+	require.Equal(t, "Fields tokenized successfully", tokenized.Message)
+}
+
+func TestIssue46_Tokenize_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.Tokenize("", blnkgo.TokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{blnkgo.TokenizableFieldFirstName},
+	})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "identity id is required")
+}
+
+func TestIssue46_Tokenize_EmptyFields(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.Tokenize("idt_test_123", blnkgo.TokenizeRequest{})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "at least one field must be specified")
+}

--- a/validate_identity.go
+++ b/validate_identity.go
@@ -49,3 +49,19 @@ func ValidateTokenizeIdentityField(identityID, field string) error {
 	}
 	return nil
 }
+
+// ValidateTokenizeIdentityRequest performs client-side checks before POST /identities/{id}/tokenize.
+func ValidateTokenizeIdentityRequest(identityID string, body TokenizeRequest) error {
+	if err := ValidateIdentityID(identityID); err != nil {
+		return err
+	}
+	if len(body.Fields) == 0 {
+		return fmt.Errorf("at least one field must be specified")
+	}
+	for _, field := range body.Fields {
+		if strings.TrimSpace(string(field)) == "" {
+			return fmt.Errorf("each field must be a non-empty string")
+		}
+	}
+	return nil
+}

--- a/validate_identity_test.go
+++ b/validate_identity_test.go
@@ -111,3 +111,18 @@ func TestValidateTokenizeIdentityField(t *testing.T) {
 	require.Error(t, blnkgo.ValidateTokenizeIdentityField("", "FirstName"))
 	require.Error(t, blnkgo.ValidateTokenizeIdentityField("idt_test_123", ""))
 }
+
+func TestValidateTokenizeIdentityRequest(t *testing.T) {
+	body := blnkgo.TokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{
+			blnkgo.TokenizableFieldFirstName,
+			blnkgo.TokenizableFieldEmailAddress,
+		},
+	}
+	require.NoError(t, blnkgo.ValidateTokenizeIdentityRequest("idt_test_123", body))
+	require.Error(t, blnkgo.ValidateTokenizeIdentityRequest("", body))
+	require.Error(t, blnkgo.ValidateTokenizeIdentityRequest("idt_test_123", blnkgo.TokenizeRequest{}))
+	require.Error(t, blnkgo.ValidateTokenizeIdentityRequest("idt_test_123", blnkgo.TokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{""},
+	}))
+}


### PR DESCRIPTION
## Summary
- Adds `Identity.Tokenize(identityID, body)` → `POST /identities/{id}/tokenize`
- Adds `TokenizeRequest` and `TokenizeResponse` types with `fields` array of PascalCase `TokenizableIdentityField` values
- Adds `ValidateTokenizeIdentityRequest` (identity id required, at least one non-empty field)
- Unit + integration tests, README example

## Test plan
- [x] `go test ./... -run 'TestIdentityService_Tokenize|TestValidateTokenizeIdentityRequest'`
- [x] `BLNK_API_KEY=blnk-local-dev-secret-change-me go test -tags=integration -v ./integration/... -run Issue46`
- [x] Postman folder **TEST — #46 Tokenize identity (run this folder only)** — POST create identity → POST tokenize