### PR TITLE
Add Identity.GetTokenizedFields (closes #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,18 @@ if err != nil {
 fmt.Println(tokenized.Message) // Fields tokenized successfully
 ```
 
+List fields currently tokenized on an identity:
+
+```go
+fields, resp, err := client.Identity.GetTokenizedFields(identity.IdentityId)
+if err != nil {
+    log.Fatal(err)
+}
+for _, field := range fields.TokenizedFields {
+    fmt.Println(field) // e.g. FirstName, EmailAddress
+}
+```
+
 ### Reconciliation
 
 The reconciliation feature allows you to match and verify transactions against external data sources.

--- a/identity.go
+++ b/identity.go
@@ -63,6 +63,11 @@ type TokenizeResponse struct {
 	Message string `json:"message"`
 }
 
+// GetTokenizedFieldsResponse lists fields currently tokenized on an identity.
+type GetTokenizedFieldsResponse struct {
+	TokenizedFields []TokenizableIdentityField `json:"tokenized_fields"`
+}
+
 func (s *IdentityService) Create(identity Identity) (*IdentityResponse, *http.Response, error) {
 	//validate the identity
 	if err := ValidateCreateIdentity(identity); err != nil {
@@ -176,6 +181,27 @@ func (s *IdentityService) Tokenize(identityID string, body TokenizeRequest) (*To
 	}
 
 	return tokenizeResp, resp, nil
+}
+
+// GetTokenizedFields returns the list of fields currently tokenized on an identity.
+func (s *IdentityService) GetTokenizedFields(identityID string) (*GetTokenizedFieldsResponse, *http.Response, error) {
+	if err := ValidateIdentityID(identityID); err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("identities/%s/tokenized-fields", identityID)
+	req, err := s.client.NewRequest(u, http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fieldsResp := new(GetTokenizedFieldsResponse)
+	resp, err := s.client.CallWithRetry(req, fieldsResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return fieldsResp, resp, nil
 }
 
 func NewIdentityService(client ClientInterface) *IdentityService {

--- a/identity_test.go
+++ b/identity_test.go
@@ -608,3 +608,77 @@ func TestIdentityService_Tokenize_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestIdentityService_GetTokenizedFields_Success(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_573ebcc9-4da0-4295-82dc-0fb152b56660"
+	path := "identities/" + identityID + "/tokenized-fields"
+
+	mockClient.On("NewRequest", path, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.GetTokenizedFieldsResponse)
+		*resp = blnkgo.GetTokenizedFieldsResponse{
+			TokenizedFields: []blnkgo.TokenizableIdentityField{
+				blnkgo.TokenizableFieldFirstName,
+				blnkgo.TokenizableFieldEmailAddress,
+			},
+		}
+	})
+
+	fields, httpResp, err := svc.GetTokenizedFields(identityID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Len(t, fields.TokenizedFields, 2)
+	assert.Equal(t, blnkgo.TokenizableFieldFirstName, fields.TokenizedFields[0])
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_GetTokenizedFields_EmptyList(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_test_123"
+	path := "identities/" + identityID + "/tokenized-fields"
+
+	mockClient.On("NewRequest", path, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.GetTokenizedFieldsResponse)
+		*resp = blnkgo.GetTokenizedFieldsResponse{TokenizedFields: []blnkgo.TokenizableIdentityField{}}
+	})
+
+	fields, httpResp, err := svc.GetTokenizedFields(identityID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Empty(t, fields.TokenizedFields)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_GetTokenizedFields_ValidationError(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	_, _, err := svc.GetTokenizedFields("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "identity id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_GetTokenizedFields_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_test_123"
+	path := "identities/" + identityID + "/tokenized-fields"
+
+	mockClient.On("NewRequest", path, http.MethodGet, nil).Return(nil, errors.New("failed to create request"))
+
+	fields, httpResp, err := svc.GetTokenizedFields(identityID)
+
+	assert.Error(t, err)
+	assert.Nil(t, fields)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -72,6 +72,7 @@ go test -tags=integration -v ./integration/...
 | #57 get reindex status | 0.13.2+ | GET /search/reindex |
 | #45 tokenize identity field | 0.13.2+ | POST /identities/{id}/tokenize/{field}; tokenization must be enabled |
 | #46 tokenize identity | 0.13.2+ | POST /identities/{id}/tokenize; tokenization must be enabled |
+| #47 get tokenized fields | 0.13.2+ | GET /identities/{id}/tokenized-fields; tokenization must be enabled |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue47_test.go
+++ b/integration/issue47_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+// Integration tests for issue #47 — Identity.GetTokenizedFields (GET /identities/{id}/tokenized-fields).
+// Requires Blnk Core running at http://localhost:5001 with tokenization enabled.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue47
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue47_GetTokenizedFields_Empty(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Fields",
+		LastName:     "Empty",
+		EmailAddress: fmt.Sprintf("issue47-empty-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	fields, resp, err := client.Identity.GetTokenizedFields(created.IdentityId)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Empty(t, fields.TokenizedFields)
+}
+
+func TestIssue47_GetTokenizedFields_AfterTokenize(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Fields",
+		LastName:     "Tokenized",
+		EmailAddress: fmt.Sprintf("issue47-tokenized-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	_, tokenizeResp, err := client.Identity.Tokenize(created.IdentityId, blnkgo.TokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{
+			blnkgo.TokenizableFieldFirstName,
+			blnkgo.TokenizableFieldLastName,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, tokenizeResp.StatusCode)
+
+	fields, resp, err := client.Identity.GetTokenizedFields(created.IdentityId)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, fields.TokenizedFields, 2)
+
+	fieldSet := map[blnkgo.TokenizableIdentityField]bool{}
+	for _, field := range fields.TokenizedFields {
+		fieldSet[field] = true
+	}
+	require.True(t, fieldSet[blnkgo.TokenizableFieldFirstName])
+	require.True(t, fieldSet[blnkgo.TokenizableFieldLastName])
+}
+
+func TestIssue47_GetTokenizedFields_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.GetTokenizedFields("")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "identity id is required")
+}
+
+func TestIssue47_GetTokenizedFields_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.GetTokenizedFields("idt_nonexistent_issue47")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary
- Adds `Identity.GetTokenizedFields(identityID)` → `GET /identities/{id}/tokenized-fields`
- Adds `GetTokenizedFieldsResponse` with `tokenized_fields []TokenizableIdentityField`
- Reuses `ValidateIdentityID` for client-side validation
- Unit + integration tests, README example

## Test plan
- [x] `go test ./... -run TestIdentityService_GetTokenizedFields`
- [x] `BLNK_API_KEY=blnk-local-dev-secret-change-me go test -tags=integration -v ./integration/... -run Issue47`
- [x] Postman folder **TEST — #47 Get tokenized fields (run this folder only)** — create identity → tokenize → GET tokenized-fields