### PR TITLE
Add Identity.DetokenizeField (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,19 @@ for _, field := range fields.TokenizedFields {
 }
 ```
 
+Detokenize a single field and read the original value:
+
+```go
+detokenized, resp, err := client.Identity.DetokenizeField(
+    identity.IdentityId,
+    string(blnkgo.TokenizableFieldEmailAddress),
+)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(detokenized.Field, detokenized.Value)
+```
+
 ### Reconciliation
 
 The reconciliation feature allows you to match and verify transactions against external data sources.

--- a/identity.go
+++ b/identity.go
@@ -68,6 +68,12 @@ type GetTokenizedFieldsResponse struct {
 	TokenizedFields []TokenizableIdentityField `json:"tokenized_fields"`
 }
 
+// DetokenizeFieldResponse is returned when a single identity field is detokenized.
+type DetokenizeFieldResponse struct {
+	Field string `json:"field"`
+	Value string `json:"value"`
+}
+
 func (s *IdentityService) Create(identity Identity) (*IdentityResponse, *http.Response, error) {
 	//validate the identity
 	if err := ValidateCreateIdentity(identity); err != nil {
@@ -202,6 +208,27 @@ func (s *IdentityService) GetTokenizedFields(identityID string) (*GetTokenizedFi
 	}
 
 	return fieldsResp, resp, nil
+}
+
+// DetokenizeField detokenizes a single PII field and returns the original value.
+func (s *IdentityService) DetokenizeField(identityID string, field string) (*DetokenizeFieldResponse, *http.Response, error) {
+	if err := ValidateTokenizeIdentityField(identityID, field); err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("identities/%s/detokenize/%s", identityID, field)
+	req, err := s.client.NewRequest(u, http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	detokenizeResp := new(DetokenizeFieldResponse)
+	resp, err := s.client.CallWithRetry(req, detokenizeResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return detokenizeResp, resp, nil
 }
 
 func NewIdentityService(client ClientInterface) *IdentityService {

--- a/identity_test.go
+++ b/identity_test.go
@@ -682,3 +682,66 @@ func TestIdentityService_GetTokenizedFields_RequestCreationFailure(t *testing.T)
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestIdentityService_DetokenizeField_Success(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_573ebcc9-4da0-4295-82dc-0fb152b56660"
+	field := string(blnkgo.TokenizableFieldEmailAddress)
+	path := "identities/" + identityID + "/detokenize/" + field
+
+	mockClient.On("NewRequest", path, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.DetokenizeFieldResponse)
+		*resp = blnkgo.DetokenizeFieldResponse{
+			Field: "EmailAddress",
+			Value: "alice.smith@example.com",
+		}
+	})
+
+	detokenized, httpResp, err := svc.DetokenizeField(identityID, field)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "EmailAddress", detokenized.Field)
+	assert.Equal(t, "alice.smith@example.com", detokenized.Value)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_DetokenizeField_ValidationErrorEmptyID(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	_, _, err := svc.DetokenizeField("", string(blnkgo.TokenizableFieldFirstName))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "identity id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_DetokenizeField_ValidationErrorEmptyField(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	_, _, err := svc.DetokenizeField("idt_test_123", "")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "field name is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_DetokenizeField_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_test_123"
+	field := string(blnkgo.TokenizableFieldPhoneNumber)
+	path := "identities/" + identityID + "/detokenize/" + field
+
+	mockClient.On("NewRequest", path, http.MethodGet, nil).Return(nil, errors.New("failed to create request"))
+
+	detokenized, httpResp, err := svc.DetokenizeField(identityID, field)
+
+	assert.Error(t, err)
+	assert.Nil(t, detokenized)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -73,6 +73,7 @@ go test -tags=integration -v ./integration/...
 | #45 tokenize identity field | 0.13.2+ | POST /identities/{id}/tokenize/{field}; tokenization must be enabled |
 | #46 tokenize identity | 0.13.2+ | POST /identities/{id}/tokenize; tokenization must be enabled |
 | #47 get tokenized fields | 0.13.2+ | GET /identities/{id}/tokenized-fields; tokenization must be enabled |
+| #48 detokenize identity field | 0.13.2+ | GET /identities/{id}/detokenize/{field}; tokenization must be enabled |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue48_test.go
+++ b/integration/issue48_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+// Integration tests for issue #48 — Identity.DetokenizeField (GET /identities/{id}/detokenize/{field}).
+// Requires Blnk Core running at http://localhost:5001 with tokenization enabled.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue48
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue48_DetokenizeField(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	email := fmt.Sprintf("issue48-%s@example.com", suffix)
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Detokenize",
+		LastName:     "Field",
+		EmailAddress: email,
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	_, tokenizeResp, err := client.Identity.TokenizeField(created.IdentityId, string(blnkgo.TokenizableFieldEmailAddress))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, tokenizeResp.StatusCode)
+
+	detokenized, detokenizeResp, err := client.Identity.DetokenizeField(created.IdentityId, string(blnkgo.TokenizableFieldEmailAddress))
+	require.NoError(t, err)
+	require.NotNil(t, detokenizeResp)
+	require.Equal(t, http.StatusOK, detokenizeResp.StatusCode)
+	require.Equal(t, string(blnkgo.TokenizableFieldEmailAddress), detokenized.Field)
+	require.Equal(t, email, detokenized.Value)
+}
+
+func TestIssue48_DetokenizeField_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.DetokenizeField("", string(blnkgo.TokenizableFieldFirstName))
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "identity id is required")
+}
+
+func TestIssue48_DetokenizeField_NotTokenized(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "NotTokenized",
+		LastName:     "Field",
+		EmailAddress: fmt.Sprintf("issue48-not-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	_, resp, err := client.Identity.DetokenizeField(created.IdentityId, string(blnkgo.TokenizableFieldFirstName))
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary
- Adds `Identity.DetokenizeField(identityID, field)` → `GET /identities/{id}/detokenize/{field}`
- Adds `DetokenizeFieldResponse` with `field` and `value`
- Reuses `ValidateTokenizeIdentityField` for client-side validation (identity id + field name)
- Unit + integration tests, README example

## Test plan
- [x] `go test ./... -run TestIdentityService_DetokenizeField`
- [x] `BLNK_API_KEY=blnk-local-dev-secret-change-me go test -tags=integration -v ./integration/... -run Issue48`
- [x] Postman folder **TEST — #48 Detokenize identity field (run this folder only)** — create identity → tokenize EmailAddress → GET detokenize