### PR TITLE
Add Identity.Detokenize for POST /identities/{id}/detokenize (closes #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,21 @@ if err != nil {
 fmt.Println(detokenized.Field, detokenized.Value)
 ```
 
+Detokenize multiple fields (pass an empty `fields` slice to detokenize all tokenized fields):
+
+```go
+detokenized, resp, err := client.Identity.Detokenize(identity.IdentityId, blnkgo.DetokenizeRequest{
+    Fields: []blnkgo.TokenizableIdentityField{
+        blnkgo.TokenizableFieldFirstName,
+        blnkgo.TokenizableFieldEmailAddress,
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(detokenized.Fields["FirstName"], detokenized.Fields["EmailAddress"])
+```
+
 ### Reconciliation
 
 The reconciliation feature allows you to match and verify transactions against external data sources.

--- a/identity.go
+++ b/identity.go
@@ -74,6 +74,17 @@ type DetokenizeFieldResponse struct {
 	Value string `json:"value"`
 }
 
+// DetokenizeRequest is the body for POST /identities/{id}/detokenize.
+// Pass an empty fields slice to detokenize all currently tokenized fields.
+type DetokenizeRequest struct {
+	Fields []TokenizableIdentityField `json:"fields"`
+}
+
+// DetokenizeResponse returns original field values keyed by field name.
+type DetokenizeResponse struct {
+	Fields map[string]string `json:"fields"`
+}
+
 func (s *IdentityService) Create(identity Identity) (*IdentityResponse, *http.Response, error) {
 	//validate the identity
 	if err := ValidateCreateIdentity(identity); err != nil {
@@ -223,6 +234,27 @@ func (s *IdentityService) DetokenizeField(identityID string, field string) (*Det
 	}
 
 	detokenizeResp := new(DetokenizeFieldResponse)
+	resp, err := s.client.CallWithRetry(req, detokenizeResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return detokenizeResp, resp, nil
+}
+
+// Detokenize detokenizes multiple PII fields and returns the original values.
+func (s *IdentityService) Detokenize(identityID string, body DetokenizeRequest) (*DetokenizeResponse, *http.Response, error) {
+	if err := ValidateDetokenizeIdentityRequest(identityID, body); err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("identities/%s/detokenize", identityID)
+	req, err := s.client.NewRequest(u, http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	detokenizeResp := new(DetokenizeResponse)
 	resp, err := s.client.CallWithRetry(req, detokenizeResp)
 	if err != nil {
 		return nil, resp, err

--- a/identity_test.go
+++ b/identity_test.go
@@ -745,3 +745,100 @@ func TestIdentityService_DetokenizeField_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestIdentityService_Detokenize_Success(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_573ebcc9-4da0-4295-82dc-0fb152b56660"
+	body := blnkgo.DetokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{
+			blnkgo.TokenizableFieldFirstName,
+			blnkgo.TokenizableFieldEmailAddress,
+		},
+	}
+	path := "identities/" + identityID + "/detokenize"
+
+	mockClient.On("NewRequest", path, http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.DetokenizeResponse)
+		*resp = blnkgo.DetokenizeResponse{
+			Fields: map[string]string{
+				"FirstName":    "Jane",
+				"EmailAddress": "jane@example.com",
+			},
+		}
+	})
+
+	detokenized, httpResp, err := svc.Detokenize(identityID, body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "Jane", detokenized.Fields["FirstName"])
+	assert.Equal(t, "jane@example.com", detokenized.Fields["EmailAddress"])
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_Detokenize_EmptyFields(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_test_123"
+	body := blnkgo.DetokenizeRequest{Fields: []blnkgo.TokenizableIdentityField{}}
+	path := "identities/" + identityID + "/detokenize"
+
+	mockClient.On("NewRequest", path, http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.DetokenizeResponse)
+		*resp = blnkgo.DetokenizeResponse{
+			Fields: map[string]string{
+				"FirstName":    "Jane",
+				"EmailAddress": "jane@example.com",
+			},
+		}
+	})
+
+	detokenized, httpResp, err := svc.Detokenize(identityID, body)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Len(t, detokenized.Fields, 2)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_Detokenize_ValidationErrorEmptyID(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	body := blnkgo.DetokenizeRequest{Fields: []blnkgo.TokenizableIdentityField{blnkgo.TokenizableFieldFirstName}}
+	_, _, err := svc.Detokenize("", body)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "identity id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_Detokenize_ValidationErrorNilFields(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	_, _, err := svc.Detokenize("idt_test_123", blnkgo.DetokenizeRequest{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fields must be an array")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_Detokenize_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_test_123"
+	body := blnkgo.DetokenizeRequest{Fields: []blnkgo.TokenizableIdentityField{blnkgo.TokenizableFieldPhoneNumber}}
+	path := "identities/" + identityID + "/detokenize"
+
+	mockClient.On("NewRequest", path, http.MethodPost, body).Return(nil, errors.New("failed to create request"))
+
+	detokenized, httpResp, err := svc.Detokenize(identityID, body)
+
+	assert.Error(t, err)
+	assert.Nil(t, detokenized)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -74,6 +74,7 @@ go test -tags=integration -v ./integration/...
 | #46 tokenize identity | 0.13.2+ | POST /identities/{id}/tokenize; tokenization must be enabled |
 | #47 get tokenized fields | 0.13.2+ | GET /identities/{id}/tokenized-fields; tokenization must be enabled |
 | #48 detokenize identity field | 0.13.2+ | GET /identities/{id}/detokenize/{field}; tokenization must be enabled |
+| #49 detokenize identity | 0.13.2+ | POST /identities/{id}/detokenize; tokenization must be enabled |
 | 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue49_test.go
+++ b/integration/issue49_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+// Integration tests for issue #49 — Identity.Detokenize (POST /identities/{id}/detokenize).
+// Requires Blnk Core running at http://localhost:5001 with tokenization enabled.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue49
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue49_Detokenize(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Detokenize",
+		LastName:     "Multi",
+		EmailAddress: fmt.Sprintf("issue49-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	_, tokenizeResp, err := client.Identity.Tokenize(created.IdentityId, blnkgo.TokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{
+			blnkgo.TokenizableFieldFirstName,
+			blnkgo.TokenizableFieldLastName,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, tokenizeResp.StatusCode)
+
+	detokenized, detokenizeResp, err := client.Identity.Detokenize(created.IdentityId, blnkgo.DetokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{
+			blnkgo.TokenizableFieldFirstName,
+			blnkgo.TokenizableFieldLastName,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, detokenizeResp)
+	require.Equal(t, http.StatusOK, detokenizeResp.StatusCode)
+	require.Equal(t, "Detokenize", detokenized.Fields["FirstName"])
+	require.Equal(t, "Multi", detokenized.Fields["LastName"])
+}
+
+func TestIssue49_Detokenize_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.Detokenize("", blnkgo.DetokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{blnkgo.TokenizableFieldFirstName},
+	})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "identity id is required")
+}
+
+func TestIssue49_Detokenize_NilFields(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.Detokenize("idt_test_123", blnkgo.DetokenizeRequest{})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "fields must be an array")
+}

--- a/validate_identity.go
+++ b/validate_identity.go
@@ -65,3 +65,19 @@ func ValidateTokenizeIdentityRequest(identityID string, body TokenizeRequest) er
 	}
 	return nil
 }
+
+// ValidateDetokenizeIdentityRequest performs client-side checks before POST /identities/{id}/detokenize.
+func ValidateDetokenizeIdentityRequest(identityID string, body DetokenizeRequest) error {
+	if err := ValidateIdentityID(identityID); err != nil {
+		return err
+	}
+	if body.Fields == nil {
+		return fmt.Errorf("fields must be an array")
+	}
+	for _, field := range body.Fields {
+		if strings.TrimSpace(string(field)) == "" {
+			return fmt.Errorf("each field must be a non-empty string")
+		}
+	}
+	return nil
+}

--- a/validate_identity_test.go
+++ b/validate_identity_test.go
@@ -126,3 +126,19 @@ func TestValidateTokenizeIdentityRequest(t *testing.T) {
 		Fields: []blnkgo.TokenizableIdentityField{""},
 	}))
 }
+
+func TestValidateDetokenizeIdentityRequest(t *testing.T) {
+	body := blnkgo.DetokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{
+			blnkgo.TokenizableFieldFirstName,
+			blnkgo.TokenizableFieldEmailAddress,
+		},
+	}
+	require.NoError(t, blnkgo.ValidateDetokenizeIdentityRequest("idt_test_123", body))
+	require.NoError(t, blnkgo.ValidateDetokenizeIdentityRequest("idt_test_123", blnkgo.DetokenizeRequest{Fields: []blnkgo.TokenizableIdentityField{}}))
+	require.Error(t, blnkgo.ValidateDetokenizeIdentityRequest("", body))
+	require.Error(t, blnkgo.ValidateDetokenizeIdentityRequest("idt_test_123", blnkgo.DetokenizeRequest{}))
+	require.Error(t, blnkgo.ValidateDetokenizeIdentityRequest("idt_test_123", blnkgo.DetokenizeRequest{
+		Fields: []blnkgo.TokenizableIdentityField{""},
+	}))
+}


### PR DESCRIPTION
## Summary
- Adds `Identity.Detokenize` for `POST /identities/{id}/detokenize` with `DetokenizeRequest` / `DetokenizeResponse` types
- Client-side validation: identity id required; `fields` must be a non-nil array (empty slice allowed for detokenize-all per API contract)
- Unit tests, integration tests (#49), README example, and Postman folder **TEST — #49 Detokenize identity**

## Test plan
- [x] `go test ./... -run 'TestIdentityService_Detokenize|TestValidateDetokenizeIdentityRequest'`
- [x] `BLNK_API_KEY=... go test -tags=integration -v ./integration/... -run Issue49`
- [x] Postman folder: create identity → tokenize → detokenize specific fields