### PR TITLE
Add Identity.Delete for DELETE /identities/{id} (closes #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,16 @@ if err != nil {
 fmt.Println(detokenized.Fields["FirstName"], detokenized.Fields["EmailAddress"])
 ```
 
+Delete an identity (Core 0.15.0+):
+
+```go
+deleted, resp, err := client.Identity.Delete(identity.IdentityId)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(deleted.Message) // Identity deleted successfully
+```
+
 ### Reconciliation
 
 The reconciliation feature allows you to match and verify transactions against external data sources.

--- a/identity.go
+++ b/identity.go
@@ -85,6 +85,11 @@ type DetokenizeResponse struct {
 	Fields map[string]string `json:"fields"`
 }
 
+// DeleteIdentityResponse is returned when an identity is deleted.
+type DeleteIdentityResponse struct {
+	Message string `json:"message"`
+}
+
 func (s *IdentityService) Create(identity Identity) (*IdentityResponse, *http.Response, error) {
 	//validate the identity
 	if err := ValidateCreateIdentity(identity); err != nil {
@@ -261,6 +266,26 @@ func (s *IdentityService) Detokenize(identityID string, body DetokenizeRequest) 
 	}
 
 	return detokenizeResp, resp, nil
+}
+
+// Delete removes an identity by ID (Core 0.15.0+).
+func (s *IdentityService) Delete(identityID string) (*DeleteIdentityResponse, *http.Response, error) {
+	if err := ValidateIdentityID(identityID); err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(fmt.Sprintf("identities/%s", identityID), http.MethodDelete, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deleteResp := new(DeleteIdentityResponse)
+	resp, err := s.client.CallWithRetry(req, deleteResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return deleteResp, resp, nil
 }
 
 func NewIdentityService(client ClientInterface) *IdentityService {

--- a/identity_test.go
+++ b/identity_test.go
@@ -842,3 +842,50 @@ func TestIdentityService_Detokenize_RequestCreationFailure(t *testing.T) {
 	assert.Nil(t, httpResp)
 	mockClient.AssertExpectations(t)
 }
+
+func TestIdentityService_Delete_Success(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_573ebcc9-4da0-4295-82dc-0fb152b56660"
+	path := "identities/" + identityID
+
+	mockClient.On("NewRequest", path, http.MethodDelete, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.DeleteIdentityResponse)
+		*resp = blnkgo.DeleteIdentityResponse{Message: "Identity deleted successfully"}
+	})
+
+	deleted, httpResp, err := svc.Delete(identityID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "Identity deleted successfully", deleted.Message)
+	mockClient.AssertExpectations(t)
+}
+
+func TestIdentityService_Delete_ValidationError(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	_, _, err := svc.Delete("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "identity id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestIdentityService_Delete_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupIdentityService()
+
+	identityID := "idt_test_123"
+	path := "identities/" + identityID
+
+	mockClient.On("NewRequest", path, http.MethodDelete, nil).Return(nil, errors.New("failed to create request"))
+
+	deleted, httpResp, err := svc.Delete(identityID)
+
+	assert.Error(t, err)
+	assert.Nil(t, deleted)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -75,6 +75,7 @@ go test -tags=integration -v ./integration/...
 | #47 get tokenized fields | 0.13.2+ | GET /identities/{id}/tokenized-fields; tokenization must be enabled |
 | #48 detokenize identity field | 0.13.2+ | GET /identities/{id}/detokenize/{field}; tokenization must be enabled |
 | #49 detokenize identity | 0.13.2+ | POST /identities/{id}/detokenize; tokenization must be enabled |
-| 0.15-only features (delete identity, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
+| #117 delete identity | 0.15.0+ | DELETE /identities/{id} |
+| 0.15-only features (delete balance monitor, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue117_test.go
+++ b/integration/issue117_test.go
@@ -1,0 +1,67 @@
+//go:build integration
+
+// Integration tests for issue #117 — Identity.Delete (DELETE /identities/{id}).
+// Requires Blnk Core 0.15.0+ at http://localhost:5001.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue117
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue117_DeleteIdentity(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	created, createResp, err := client.Identity.Create(blnkgo.Identity{
+		IdentityType: blnkgo.Individual,
+		FirstName:    "Delete",
+		LastName:     "Me",
+		EmailAddress: fmt.Sprintf("issue117-%s@example.com", suffix),
+		PhoneNumber:  "1234567890",
+		Category:     "customer",
+		Street:       "123 Main St",
+		Country:      "USA",
+		State:        "CA",
+		PostCode:     "90001",
+		City:         "Los Angeles",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	deleted, deleteResp, err := client.Identity.Delete(created.IdentityId)
+	require.NoError(t, err)
+	require.NotNil(t, deleteResp)
+	require.Equal(t, http.StatusOK, deleteResp.StatusCode)
+	require.Equal(t, "Identity deleted successfully", deleted.Message)
+
+	_, getResp, err := client.Identity.Get(created.IdentityId)
+	require.Error(t, err)
+	require.NotNil(t, getResp)
+	require.NotEqual(t, http.StatusOK, getResp.StatusCode)
+}
+
+func TestIssue117_DeleteIdentity_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.Delete("")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "identity id is required")
+}
+
+func TestIssue117_DeleteIdentity_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Identity.Delete("idt_nonexistent_issue117")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary
- Adds `Identity.Delete(identityID)` for `DELETE /identities/{id}` (Core 0.15.0+)
- `DeleteIdentityResponse` with `message` field
- Reuses `ValidateIdentityID` for client-side validation
- Unit tests, integration tests (#117), README example

## Test plan
- [x] `go test ./... -run TestIdentityService_Delete`
- [x] `BLNK_API_KEY=... go test -tags=integration -v ./integration/... -run Issue117` (Core 0.15.0)
- [x] Postman folder **TEST — #117 Delete identity (run this folder only)**