### PR TITLE
Add BalanceMonitor.Delete for DELETE /balance-monitors/{id} (closes #118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,16 @@ if err != nil {
 fmt.Printf("Monitor Created: %+v\n", monitor)
 ```
 
+Delete a balance monitor (Core 0.15.0+):
+
+```go
+deleted, resp, err := client.BalanceMonitor.Delete(monitor.MonitorID)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(deleted.Message) // BalanceMonitor deleted successfully
+```
+
 ### Identity Management
 
 Manage customer or organizational identities within your ledger system.

--- a/balance_monitor.go
+++ b/balance_monitor.go
@@ -1,6 +1,9 @@
 package blnkgo
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 type BalanceMonitorService service
 
@@ -24,6 +27,11 @@ type MonitorDataResp struct {
 	MonitorData
 	MonitorID string `json:"monitor_id"`
 	CreatedAt string `json:"created_at"` // ISO date string
+}
+
+// DeleteBalanceMonitorResponse is returned when a balance monitor is deleted.
+type DeleteBalanceMonitorResponse struct {
+	Message string `json:"message"`
 }
 
 func (s *BalanceMonitorService) Create(data MonitorData) (*MonitorDataResp, *http.Response, error) {
@@ -84,6 +92,26 @@ func (s *BalanceMonitorService) Update(monitorID string, data MonitorData) (*Mon
 	}
 
 	return monitorData, resp, nil
+}
+
+// Delete removes a balance monitor by ID (Core 0.15.0+).
+func (s *BalanceMonitorService) Delete(monitorID string) (*DeleteBalanceMonitorResponse, *http.Response, error) {
+	if err := ValidateMonitorID(monitorID); err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(fmt.Sprintf("balance-monitors/%s", monitorID), http.MethodDelete, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deleteResp := new(DeleteBalanceMonitorResponse)
+	resp, err := s.client.CallWithRetry(req, deleteResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return deleteResp, resp, nil
 }
 
 func NewBalanceMonitorService(client ClientInterface) *BalanceMonitorService {

--- a/balance_monitor_test.go
+++ b/balance_monitor_test.go
@@ -316,3 +316,50 @@ func TestBalanceMonitorService_Update_ServerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "server error")
 	mockClient.AssertExpectations(t)
 }
+
+func TestBalanceMonitorService_Delete_Success(t *testing.T) {
+	mockClient, svc := setupBalanceMonitorService()
+
+	monitorID := "mon_test_123"
+	path := "balance-monitors/" + monitorID
+
+	mockClient.On("NewRequest", path, http.MethodDelete, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*blnkgo.DeleteBalanceMonitorResponse)
+		*resp = blnkgo.DeleteBalanceMonitorResponse{Message: "BalanceMonitor deleted successfully"}
+	})
+
+	deleted, httpResp, err := svc.Delete(monitorID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, "BalanceMonitor deleted successfully", deleted.Message)
+	mockClient.AssertExpectations(t)
+}
+
+func TestBalanceMonitorService_Delete_ValidationError(t *testing.T) {
+	mockClient, svc := setupBalanceMonitorService()
+
+	_, _, err := svc.Delete("")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "monitor id is required")
+	mockClient.AssertNotCalled(t, "NewRequest", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestBalanceMonitorService_Delete_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupBalanceMonitorService()
+
+	monitorID := "mon_test_123"
+	path := "balance-monitors/" + monitorID
+
+	mockClient.On("NewRequest", path, http.MethodDelete, nil).Return(nil, errors.New("failed to create request"))
+
+	deleted, httpResp, err := svc.Delete(monitorID)
+
+	assert.Error(t, err)
+	assert.Nil(t, deleted)
+	assert.Nil(t, httpResp)
+	mockClient.AssertExpectations(t)
+}

--- a/integration/README.md
+++ b/integration/README.md
@@ -76,6 +76,6 @@ go test -tags=integration -v ./integration/...
 | #48 detokenize identity field | 0.13.2+ | GET /identities/{id}/detokenize/{field}; tokenization must be enabled |
 | #49 detokenize identity | 0.13.2+ | POST /identities/{id}/detokenize; tokenization must be enabled |
 | #117 delete identity | 0.15.0+ | DELETE /identities/{id} |
-| 0.15-only features (delete balance monitor, etc.) | 0.15.0 | Test when we reach remaining Go 1.3.0 issues |
+| #118 delete balance monitor | 0.15.0+ | DELETE /balance-monitors/{id} |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue118_test.go
+++ b/integration/issue118_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+// Integration tests for issue #118 — BalanceMonitor.Delete (DELETE /balance-monitors/{id}).
+// Requires Blnk Core 0.15.0+ at http://localhost:5001.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue118
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func createBalanceMonitorForTest(t *testing.T, client *blnkgo.Client) string {
+	t.Helper()
+
+	ledger, ledgerResp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{
+		Name: fmt.Sprintf("issue118-ledger-%d", time.Now().UnixNano()),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, ledgerResp.StatusCode)
+
+	balance, balanceResp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, balanceResp.StatusCode)
+
+	monitor, monitorResp, err := client.BalanceMonitor.Create(blnkgo.MonitorData{
+		BalanceID: balance.BalanceID,
+		Condition: blnkgo.MonitorCondition{
+			Field:     "credit_balance",
+			Operator:  blnkgo.OperatorGreaterThan,
+			Value:     1000,
+			Precision: 100,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, monitorResp.StatusCode)
+	require.NotEmpty(t, monitor.MonitorID)
+
+	return monitor.MonitorID
+}
+
+func TestIssue118_DeleteBalanceMonitor(t *testing.T) {
+	client := newIntegrationClient(t)
+	monitorID := createBalanceMonitorForTest(t, client)
+
+	deleted, deleteResp, err := client.BalanceMonitor.Delete(monitorID)
+	require.NoError(t, err)
+	require.NotNil(t, deleteResp)
+	require.Equal(t, http.StatusOK, deleteResp.StatusCode)
+	require.Equal(t, "BalanceMonitor deleted successfully", deleted.Message)
+
+	_, getResp, err := client.BalanceMonitor.Get(monitorID)
+	require.Error(t, err)
+	require.NotNil(t, getResp)
+	require.NotEqual(t, http.StatusOK, getResp.StatusCode)
+}
+
+func TestIssue118_DeleteBalanceMonitor_ValidationError(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.BalanceMonitor.Delete("")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "monitor id is required")
+}
+
+func TestIssue118_DeleteBalanceMonitor_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.BalanceMonitor.Delete("mon_nonexistent_issue118")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}

--- a/validate_balance_monitor.go
+++ b/validate_balance_monitor.go
@@ -1,0 +1,14 @@
+package blnkgo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateMonitorID performs client-side checks before balance monitor operations that require an ID.
+func ValidateMonitorID(monitorID string) error {
+	if strings.TrimSpace(monitorID) == "" {
+		return fmt.Errorf("monitor id is required")
+	}
+	return nil
+}

--- a/validate_balance_monitor_test.go
+++ b/validate_balance_monitor_test.go
@@ -1,0 +1,14 @@
+package blnkgo_test
+
+import (
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMonitorID(t *testing.T) {
+	require.NoError(t, blnkgo.ValidateMonitorID("mon_test_123"))
+	require.Error(t, blnkgo.ValidateMonitorID(""))
+	require.Error(t, blnkgo.ValidateMonitorID("   "))
+}


### PR DESCRIPTION
## Summary
- Adds `BalanceMonitor.Delete(monitorID)` for `DELETE /balance-monitors/{id}` (Core 0.15.0+)
- `DeleteBalanceMonitorResponse` with `message` field
- `ValidateMonitorID` for client-side validation
- Unit tests, integration tests (#118), README example

## Test plan
- [x] `go test ./... -run 'TestBalanceMonitorService_Delete|TestValidateMonitorID'`
- [x] `BLNK_API_KEY=... go test -tags=integration -v ./integration/... -run Issue118` (Core 0.15.0)
- [x] Postman folder **TEST — #118 Delete balance monitor (run this folder only)**