### PR TITLE
Fix Reconciliation.Run response type for Core 0.15.0 (closes #119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,11 @@ reconBody := blnkgo.RunReconData{
 }
 
 reconResp, resp, err := client.Reconciliation.Run(reconBody)
+if err != nil {
+    log.Fatal(err)
+}
+// reconResp.ReconciliationID — use webhooks or GET /reconciliation/{id} for results (Core 0.15.0+)
+fmt.Println(reconResp.ReconciliationID)
 ```
 
 #### Run Instant Reconciliation

--- a/examples/reconciliation/main.go
+++ b/examples/reconciliation/main.go
@@ -61,5 +61,5 @@ func main() {
 	}
 
 	fmt.Print(resp.StatusCode)
-	fmt.Printf("%+v\n", runRecon)
+	fmt.Println(runRecon.ReconciliationID)
 }

--- a/integration/README.md
+++ b/integration/README.md
@@ -77,5 +77,6 @@ go test -tags=integration -v ./integration/...
 | #49 detokenize identity | 0.13.2+ | POST /identities/{id}/detokenize; tokenization must be enabled |
 | #117 delete identity | 0.15.0+ | DELETE /identities/{id} |
 | #118 delete balance monitor | 0.15.0+ | DELETE /balance-monitors/{id} |
+| #119 reconciliation run response | 0.15.0+ | POST /reconciliation/start returns reconciliation_id only |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue119_test.go
+++ b/integration/issue119_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+// Integration tests for issue #119 — Reconciliation.Run response (POST /reconciliation/start).
+// Requires Blnk Core 0.15.0+ at http://localhost:5001.
+//
+// Run: go test -tags=integration -v ./integration/... -run Issue119
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func createReconMatchingRuleForIssue119(t *testing.T, client *blnkgo.Client) string {
+	t.Helper()
+
+	matcher, resp, err := client.Reconciliation.CreateMatchingRule(blnkgo.Matcher{
+		Name:        fmt.Sprintf("Issue119 rule %d", time.Now().UnixNano()),
+		Description: "Amount match for reconciliation start",
+		Criteria: []blnkgo.Criteria{
+			{
+				Field:    blnkgo.CriteriaFieldAmount,
+				Operator: blnkgo.ReconciliationOperatorEquals,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, matcher.RuleID)
+	return matcher.RuleID
+}
+
+func writeIssue119CSV(t *testing.T) string {
+	t.Helper()
+
+	extID := fmt.Sprintf("ext-issue119-%d", time.Now().UnixNano())
+	content := fmt.Sprintf("ID,Amount,Currency,Reference,Description,Date\n%s,100.50,USD,ref-issue119,test row,2024-01-01T10:00:00Z\n", extID)
+	path := filepath.Join(t.TempDir(), "issue119.csv")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestIssue119_Run_StartResponse(t *testing.T) {
+	client := newIntegrationClient(t)
+	ruleID := createReconMatchingRuleForIssue119(t, client)
+
+	csvPath := writeIssue119CSV(t)
+	uploaded, uploadResp, err := client.Reconciliation.Upload("integration-test", csvPath, "issue119.csv")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, uploadResp.StatusCode)
+	require.NotEmpty(t, uploaded.UploadID)
+
+	result, resp, err := client.Reconciliation.Run(blnkgo.RunReconData{
+		UploadID:        uploaded.UploadID,
+		Strategy:        blnkgo.ReconciliationStrategyOneToOne,
+		DryRun:          true,
+		MatchingRuleIDs: []string{ruleID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, result.ReconciliationID)
+	require.Contains(t, result.ReconciliationID, "recon_")
+}

--- a/reconciliation.go
+++ b/reconciliation.go
@@ -44,6 +44,15 @@ type RunReconResp struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
+// StartReconciliationResponse is returned when a reconciliation run is started
+// via POST /reconciliation/start or POST /reconciliation/start-instant (Core 0.15.0+).
+type StartReconciliationResponse struct {
+	ReconciliationID string `json:"reconciliation_id"`
+}
+
+// RunInstantReconResp is returned when instant reconciliation is started.
+type RunInstantReconResp = StartReconciliationResponse
+
 // DeleteMatchingRuleResp is returned when a matching rule is deleted.
 type DeleteMatchingRuleResp struct {
 	Message string `json:"message"`
@@ -68,11 +77,6 @@ type RunInstantReconData struct {
 	GroupingCriteria     CriteriaField          `json:"grouping_criteria,omitempty"`
 	DryRun               bool                   `json:"dry_run,omitempty"`
 	MatchingRuleIDs      []string               `json:"matching_rule_ids"`
-}
-
-// RunInstantReconResp is returned when instant reconciliation is started.
-type RunInstantReconResp struct {
-	ReconciliationID string `json:"reconciliation_id"`
 }
 
 // Reconciliation is the status and counts for a reconciliation run.
@@ -180,12 +184,12 @@ func (s *ReconciliationService) Get(reconciliationID string) (*Reconciliation, *
 	return recon, resp, nil
 }
 
-func (s *ReconciliationService) Run(data RunReconData) (*RunReconResp, *http.Response, error) {
+func (s *ReconciliationService) Run(data RunReconData) (*StartReconciliationResponse, *http.Response, error) {
 	req, err := s.client.NewRequest("reconciliation/start", http.MethodPost, data)
 	if err != nil {
 		return nil, nil, err
 	}
-	reconResp := new(RunReconResp)
+	reconResp := new(StartReconciliationResponse)
 	resp, err := s.client.CallWithRetry(req, reconResp)
 	if err != nil {
 		return nil, resp, err

--- a/reconciliation_test.go
+++ b/reconciliation_test.go
@@ -121,14 +121,13 @@ func TestReconciliationService_Run_Success(t *testing.T) {
 		MatchingRuleIDs:  []string{"rule-123"},
 	}
 
-	expectedResp := &blnkgo.RunReconResp{
-		RuleID:    "rule-123",
-		CreatedAt: time.Now().Format(time.RFC3339),
+	expectedResp := &blnkgo.StartReconciliationResponse{
+		ReconciliationID: "recon_test_123",
 	}
 
 	mockClient.On("NewRequest", "reconciliation/start", http.MethodPost, data).Return(&http.Request{}, nil)
 	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
-		resp := args.Get(1).(*blnkgo.RunReconResp)
+		resp := args.Get(1).(*blnkgo.StartReconciliationResponse)
 		*resp = *expectedResp
 	})
 
@@ -139,6 +138,13 @@ func TestReconciliationService_Run_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
 	assert.Equal(t, expectedResp, resp)
 	mockClient.AssertExpectations(t)
+}
+
+func TestReconciliationService_Run_ResponseUnmarshalJSON(t *testing.T) {
+	var resp blnkgo.StartReconciliationResponse
+	err := json.Unmarshal([]byte(`{"reconciliation_id":"recon_abc123"}`), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "recon_abc123", resp.ReconciliationID)
 }
 
 func TestReconciliationService_Run_RequestCreationFailure(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Reconciliation.Run` now returns `StartReconciliationResponse` with only `reconciliation_id` (Core 0.15.0)
- `RunInstantReconResp` is a type alias of `StartReconciliationResponse`
- `RunReconResp` unchanged for matching rule create/update responses
- Unit + integration tests (#119), README and example updates

## Test plan
- [x] `go test ./... -run TestReconciliationService_Run`
- [x] `BLNK_API_KEY=... go test -tags=integration -v ./integration/... -run Issue119`