### PR TITLE
Enforce 10,000 max on CreateBulk client validation (closes #120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ fmt.Printf("Transaction Recorded: %+v\n", newTransaction)
 
 ### Recording Bulk Transactions
 
-Submit multiple transactions in a single request. Set `Atomic` to ensure all transactions succeed or fail together:
+Submit multiple transactions in a single request (up to `MaxBulkCreateItems`, 10,000 per request). Set `Atomic` to ensure all transactions succeed or fail together:
 
 ```go
 bulkBody := blnkgo.CreateBulkTransactionRequest{

--- a/transaction.go
+++ b/transaction.go
@@ -85,6 +85,10 @@ type RefundTransactionRequest struct {
 // bulk commit or bulk void call.
 const MaxBulkInflightItems = 100
 
+// MaxBulkCreateItems caps the number of transactions accepted in a single
+// CreateBulk call (POST /transactions/bulk).
+const MaxBulkCreateItems = 10000
+
 // BulkCommitInflightItem describes one transaction in a bulk commit request.
 // Zero amount means commit the full remaining inflight amount; non-zero performs
 // a partial commit. PreciseAmount, when set, takes precedence over Amount.

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1168,6 +1168,20 @@ func TestTransactionService_CreateBulk_EmptyTransactions(t *testing.T) {
 	mockClient.AssertNotCalled(t, "CallWithRetry")
 }
 
+func TestTransactionService_CreateBulk_TooManyTransactions(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+	txns := make([]blnkgo.CreateTransactionRequest, blnkgo.MaxBulkCreateItems+1)
+
+	result, resp, err := svc.CreateBulk(blnkgo.CreateBulkTransactionRequest{Transactions: txns})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many transactions")
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+	mockClient.AssertNotCalled(t, "NewRequest")
+	mockClient.AssertNotCalled(t, "CallWithRetry")
+}
+
 func TestTransactionService_CreateBulk_InvalidTransaction(t *testing.T) {
 	mockClient, svc := setupTransactionService()
 	body := validBulkTransactionRequest()

--- a/validate_transactions.go
+++ b/validate_transactions.go
@@ -88,6 +88,9 @@ func ValidateCreateBulkTransaction(b CreateBulkTransactionRequest) error {
 	if len(b.Transactions) == 0 {
 		return errors.New("validation error: transactions array cannot be empty")
 	}
+	if len(b.Transactions) > MaxBulkCreateItems {
+		return fmt.Errorf("validation error: too many transactions; max is %d", MaxBulkCreateItems)
+	}
 
 	refs := make(map[string]struct{}, len(b.Transactions))
 	for i, tx := range b.Transactions {

--- a/validate_transactions_test.go
+++ b/validate_transactions_test.go
@@ -1,6 +1,7 @@
 package blnkgo_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -162,4 +163,39 @@ func TestValidateCreateTransaction_PreciseAmountWithPreciseDistributionStillVali
 	err := blnkgo.ValidateCreateTransacation(txn)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not equal")
+}
+
+func bulkCreateTransactions(n int) []blnkgo.CreateTransactionRequest {
+	txns := make([]blnkgo.CreateTransactionRequest, n)
+	for i := range txns {
+		txns[i] = blnkgo.CreateTransactionRequest{
+			ParentTransaction: blnkgo.ParentTransaction{
+				Amount:      100,
+				Reference:   fmt.Sprintf("bulk-ref-%d", i),
+				Precision:   100,
+				Currency:    "USD",
+				Source:      "@FundingPool",
+				Destination: "@Recipient",
+				Description: "Bulk transaction",
+			},
+		}
+	}
+	return txns
+}
+
+func TestValidateCreateBulkTransaction_AtLimit(t *testing.T) {
+	body := blnkgo.CreateBulkTransactionRequest{
+		Transactions: bulkCreateTransactions(blnkgo.MaxBulkCreateItems),
+	}
+	require.NoError(t, blnkgo.ValidateCreateBulkTransaction(body))
+}
+
+func TestValidateCreateBulkTransaction_OverLimit(t *testing.T) {
+	body := blnkgo.CreateBulkTransactionRequest{
+		Transactions: bulkCreateTransactions(blnkgo.MaxBulkCreateItems + 1),
+	}
+	err := blnkgo.ValidateCreateBulkTransaction(body)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many transactions")
+	require.Contains(t, err.Error(), "10000")
 }


### PR DESCRIPTION
## Summary
- Add `MaxBulkCreateItems = 10000` constant for `POST /transactions/bulk`
- Reject bulk create requests with more than 10,000 transactions in `ValidateCreateBulkTransaction` before hitting Core
- Unit tests for at-limit (10,000) and over-limit (10,001) cases
- Note the limit in README bulk transactions section

## Test plan
- [x] `go test ./... -run 'CreateBulk|ValidateCreateBulk'`
- [x] At-limit validator accepts exactly 10,000 valid transactions
- [x] Over-limit returns client validation error without calling API