### PR TITLE
Expose structured error_detail on API errors (closes #121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The official Go SDK for Blnk - A powerful ledger system for financial applicatio
   - [Identity Management](#identity-management)
   - [Reconciliation](#reconciliation)
   - [Search](#search)
+  - [Error Handling](#error-handling)
 - [8. Examples](#8-examples)
 - [Additional Resources](#additional-resources)
 
@@ -1053,6 +1054,32 @@ if err != nil {
 }
 fmt.Println(progress.Status, progress.Phase, progress.ProcessedRecords, progress.TotalRecords)
 ```
+
+### Error Handling
+
+Core 0.15.0+ returns structured errors with an `error_detail` object. When a service method returns an error, use `errors.As` to read the stable machine code — do not branch on message text:
+
+```go
+_, resp, err := client.Transaction.Get("txn_missing")
+if err != nil {
+    var apiErr *blnkgo.ApiErrorResponse
+    if errors.As(err, &apiErr) && apiErr.ErrorDetail != nil {
+        switch apiErr.ErrorDetail.Code {
+        case "TXN_NOT_FOUND":
+            // handle missing transaction
+        case "GEN_CONFLICT":
+            // handle conflict
+        default:
+            fmt.Printf("API error %s: %s\n", apiErr.ErrorDetail.Code, apiErr.ErrorDetail.Message)
+        }
+    }
+    return
+}
+```
+
+Legacy responses with only a flat `"error"` string are mapped to `ErrorDetail.Code == "UNKNOWN"`. The raw response body remains available on `ApiErrorResponse.Body` for backward compatibility.
+
+See [Blnk error codes](https://docs.blnkfinance.com/advanced/error-codes) for the full catalog.
 
 ---
 

--- a/api_error.go
+++ b/api_error.go
@@ -1,55 +1,97 @@
 package blnkgo
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 )
 
-//This function will take in Resp as a parameter and check the status code, for error in the range of 400 return a 400 error, for error in the range of 500 return a 500 error, for success return nil
-
-// we create a struct for api error response
-type ApiErrorResponse struct {
-	Status  int    `json:"status"`
-	Message string `json:"message"`
-	Body    []byte `json:"body"`
+// ApiErrorDetail is the structured error payload returned by Core 0.15.0+.
+type ApiErrorDetail struct {
+	Code    string      `json:"code"`
+	Message string      `json:"message"`
+	Details interface{} `json:"details,omitempty"`
 }
 
-// implement the error interface for ApiErrorResponse
+// ApiErrorResponse represents a non-success HTTP response from the Blnk API.
+type ApiErrorResponse struct {
+	Status      int             `json:"status"`
+	Message     string          `json:"message"`
+	LegacyError string          `json:"error,omitempty"`
+	ErrorDetail *ApiErrorDetail `json:"error_detail,omitempty"`
+	Body        []byte          `json:"body"`
+}
+
 func (a *ApiErrorResponse) Error() string {
+	if a.ErrorDetail != nil && a.ErrorDetail.Code != "" {
+		return fmt.Sprintf("Status: %d, Code: %s, Message: %s", a.Status, a.ErrorDetail.Code, a.ErrorDetail.Message)
+	}
+	if a.ErrorDetail != nil && a.ErrorDetail.Message != "" {
+		return fmt.Sprintf("Status: %d, Message: %s", a.Status, a.ErrorDetail.Message)
+	}
+	if a.LegacyError != "" {
+		return fmt.Sprintf("Status: %d, Message: %s", a.Status, a.LegacyError)
+	}
 	return fmt.Sprintf("Status: %d, Message: %s, Body: %s", a.Status, a.Message, a.Body)
 }
-func (c *Client) CheckResponse(resp *http.Response) error {
-	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-		//read the response body
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		//create a new api error response
-		apiErrorResponse := &ApiErrorResponse{
-			Status:  resp.StatusCode,
-			Message: resp.Status,
-			Body:    body,
-		}
-		//return the error
-		return apiErrorResponse
+
+// AsApiErrorResponse returns the Blnk API error when err wraps ApiErrorResponse.
+func AsApiErrorResponse(err error) (*ApiErrorResponse, bool) {
+	var apiErr *ApiErrorResponse
+	if errors.As(err, &apiErr) {
+		return apiErr, true
+	}
+	return nil, false
+}
+
+// ParseApiErrorBody extracts structured error_detail (and legacy error) from a JSON body.
+func ParseApiErrorBody(body []byte) (legacyError string, detail *ApiErrorDetail) {
+	if len(body) == 0 {
+		return "", nil
 	}
 
-	if resp.StatusCode >= 500 {
-		//read the response body
+	var payload struct {
+		Error       string          `json:"error"`
+		ErrorDetail *ApiErrorDetail `json:"error_detail"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", nil
+	}
+
+	if payload.ErrorDetail != nil && payload.ErrorDetail.Code != "" && payload.ErrorDetail.Message != "" {
+		return payload.Error, payload.ErrorDetail
+	}
+
+	if payload.Error != "" {
+		return payload.Error, &ApiErrorDetail{
+			Code:    "UNKNOWN",
+			Message: payload.Error,
+		}
+	}
+
+	return payload.Error, nil
+}
+
+func newApiErrorResponse(statusCode int, statusText string, body []byte) *ApiErrorResponse {
+	legacyError, detail := ParseApiErrorBody(body)
+	return &ApiErrorResponse{
+		Status:      statusCode,
+		Message:     statusText,
+		LegacyError: legacyError,
+		ErrorDetail: detail,
+		Body:        body,
+	}
+}
+
+func (c *Client) CheckResponse(resp *http.Response) error {
+	if resp.StatusCode >= 400 {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
-		//create a new api error response
-		apiErrorResponse := &ApiErrorResponse{
-			Status:  resp.StatusCode,
-			Message: resp.Status,
-			Body:    body,
-		}
-		//return the error
-		return apiErrorResponse
+		return newApiErrorResponse(resp.StatusCode, resp.Status, body)
 	}
 
 	return nil

--- a/api_error_test.go
+++ b/api_error_test.go
@@ -1,0 +1,130 @@
+package blnkgo_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseApiErrorBody_StructuredErrorDetail(t *testing.T) {
+	body := []byte(`{
+		"error": "transaction not found",
+		"error_detail": {
+			"code": "TXN_NOT_FOUND",
+			"message": "transaction not found",
+			"details": {}
+		}
+	}`)
+
+	legacy, detail := blnkgo.ParseApiErrorBody(body)
+	require.NotNil(t, detail)
+	assert.Equal(t, "transaction not found", legacy)
+	assert.Equal(t, "TXN_NOT_FOUND", detail.Code)
+	assert.Equal(t, "transaction not found", detail.Message)
+	assert.NotNil(t, detail.Details)
+}
+
+func TestParseApiErrorBody_ConflictWithDetails(t *testing.T) {
+	body := []byte(`{
+		"error": "duplicate reference",
+		"error_detail": {
+			"code": "TXN_DUPLICATE_REFERENCE",
+			"message": "duplicate reference",
+			"details": {"reference": "ref_001"}
+		}
+	}`)
+
+	_, detail := blnkgo.ParseApiErrorBody(body)
+	require.NotNil(t, detail)
+	assert.Equal(t, "TXN_DUPLICATE_REFERENCE", detail.Code)
+	assert.Equal(t, "duplicate reference", detail.Message)
+}
+
+func TestParseApiErrorBody_LegacyErrorOnly(t *testing.T) {
+	body := []byte(`{"error": "ledger not found"}`)
+
+	legacy, detail := blnkgo.ParseApiErrorBody(body)
+	assert.Equal(t, "ledger not found", legacy)
+	require.NotNil(t, detail)
+	assert.Equal(t, "UNKNOWN", detail.Code)
+	assert.Equal(t, "ledger not found", detail.Message)
+}
+
+func TestParseApiErrorBody_EmptyBody(t *testing.T) {
+	legacy, detail := blnkgo.ParseApiErrorBody(nil)
+	assert.Empty(t, legacy)
+	assert.Nil(t, detail)
+}
+
+func TestParseApiErrorBody_InvalidJSON(t *testing.T) {
+	legacy, detail := blnkgo.ParseApiErrorBody([]byte(`not json`))
+	assert.Empty(t, legacy)
+	assert.Nil(t, detail)
+}
+
+func TestCheckResponse_AttachesErrorDetail(t *testing.T) {
+	client := &blnkgo.Client{}
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Status:     "404 Not Found",
+		Body: io.NopCloser(strings.NewReader(`{
+			"error": "transaction not found",
+			"error_detail": {
+				"code": "TXN_NOT_FOUND",
+				"message": "transaction not found",
+				"details": {}
+			}
+		}`)),
+	}
+
+	err := client.CheckResponse(resp)
+	require.Error(t, err)
+
+	apiErr, ok := blnkgo.AsApiErrorResponse(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusNotFound, apiErr.Status)
+	assert.Equal(t, "transaction not found", apiErr.LegacyError)
+	require.NotNil(t, apiErr.ErrorDetail)
+	assert.Equal(t, "TXN_NOT_FOUND", apiErr.ErrorDetail.Code)
+}
+
+func TestCheckResponse_LockedErrorDetail(t *testing.T) {
+	client := &blnkgo.Client{}
+	resp := &http.Response{
+		StatusCode: http.StatusLocked,
+		Status:     "423 Locked",
+		Body: io.NopCloser(strings.NewReader(`{
+			"error": "resource locked",
+			"error_detail": {
+				"code": "GEN_RESOURCE_LOCKED",
+				"message": "resource locked",
+				"details": {}
+			}
+		}`)),
+	}
+
+	err := client.CheckResponse(resp)
+	require.Error(t, err)
+
+	apiErr, ok := blnkgo.AsApiErrorResponse(err)
+	require.True(t, ok)
+	require.NotNil(t, apiErr.ErrorDetail)
+	assert.Equal(t, "GEN_RESOURCE_LOCKED", apiErr.ErrorDetail.Code)
+}
+
+func TestApiErrorResponse_ErrorStringUsesCode(t *testing.T) {
+	apiErr := &blnkgo.ApiErrorResponse{
+		Status: 409,
+		ErrorDetail: &blnkgo.ApiErrorDetail{
+			Code:    "GEN_CONFLICT",
+			Message: "conflict",
+		},
+	}
+	assert.Contains(t, apiErr.Error(), "GEN_CONFLICT")
+	assert.Contains(t, apiErr.Error(), "conflict")
+}


### PR DESCRIPTION
## Summary
- Add `ApiErrorDetail` with `code`, `message`, and `details`
- Parse `error` and `error_detail` from error response bodies in `CheckResponse`
- Expose typed fields on `ApiErrorResponse` plus `AsApiErrorResponse` helper
- Legacy flat `"error"` strings map to `ErrorDetail.Code == "UNKNOWN"`
- Unit tests for Core 0.15 sample payloads (404, 409, 423)
- README error-handling guidance: branch on `error_detail.code`

## Test plan
- [x] `go test ./... -run 'ApiError|ParseApiError|CheckResponse'`
- [x] Full `go test ./...`