### PR TITLE
Add MetaData type alias for resource metadata fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ func main() {
     // Create a new ledger
     ledgerBody := blnkgo.CreateLedgerRequest{
         Name: "Customer Savings Account",
-        MetaData: map[string]interface{}{
+        MetaData: MetaData{
             "project_owner": "YOUR_APP_NAME",
         },
     }
@@ -213,7 +213,7 @@ To create a balance, specify the `ledger_id` and other details:
 balanceBody := blnkgo.CreateLedgerBalanceRequest{
     LedgerID: "ldg_073f7ffe-9dfd-42ce-aa50-d1dca1788adc",
     Currency: "USD",
-    MetaData: map[string]interface{}{
+    MetaData: MetaData{
         "first_name":     "Alice",
         "last_name":      "Hart",
         "account_number": "1234567890",
@@ -332,7 +332,7 @@ transactionBody := blnkgo.CreateTransactionRequest{
         Source:      "bln_28edb3e5-c168-4127-a1c4-16274e7a28d3",
         Destination: "bln_ebcd230f-6265-4d4a-a4ca-45974c47f746",
         Description: "Sent from app",
-        MetaData: map[string]interface{}{
+        MetaData: MetaData{
             "sender_name":    "John Doe",
             "sender_account": "00000000000",
         },
@@ -641,7 +641,7 @@ identityBody := blnkgo.Identity{
     State:        "NY",
     Country:      "USA",
     PostCode:     "10001",
-    MetaData: map[string]interface{}{
+    MetaData: MetaData{
         "customer_tier": "premium",
     },
 }

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ func main() {
     // Create a new ledger
     ledgerBody := blnkgo.CreateLedgerRequest{
         Name: "Customer Savings Account",
-        MetaData: MetaData{
+        MetaData: blnkgo.MetaData{
             "project_owner": "YOUR_APP_NAME",
         },
     }
@@ -213,7 +213,7 @@ To create a balance, specify the `ledger_id` and other details:
 balanceBody := blnkgo.CreateLedgerBalanceRequest{
     LedgerID: "ldg_073f7ffe-9dfd-42ce-aa50-d1dca1788adc",
     Currency: "USD",
-    MetaData: MetaData{
+    MetaData: blnkgo.MetaData{
         "first_name":     "Alice",
         "last_name":      "Hart",
         "account_number": "1234567890",
@@ -332,7 +332,7 @@ transactionBody := blnkgo.CreateTransactionRequest{
         Source:      "bln_28edb3e5-c168-4127-a1c4-16274e7a28d3",
         Destination: "bln_ebcd230f-6265-4d4a-a4ca-45974c47f746",
         Description: "Sent from app",
-        MetaData: MetaData{
+        MetaData: blnkgo.MetaData{
             "sender_name":    "John Doe",
             "sender_account": "00000000000",
         },
@@ -641,7 +641,7 @@ identityBody := blnkgo.Identity{
     State:        "NY",
     Country:      "USA",
     PostCode:     "10001",
-    MetaData: MetaData{
+    MetaData: blnkgo.MetaData{
         "customer_tier": "premium",
     },
 }

--- a/examples/balance-monitor/main.go
+++ b/examples/balance-monitor/main.go
@@ -13,7 +13,7 @@ func main() {
 
 	ledgerBody := blnkgo.CreateLedgerRequest{
 		Name: "Ledge",
-		MetaData: map[string]interface{}{
+		MetaData: blnkgo.MetaData{
 			"project_name": "SendWorldApp",
 		},
 	}
@@ -31,7 +31,7 @@ func main() {
 	ledgerBalanceBody := blnkgo.CreateLedgerBalanceRequest{
 		LedgerID: ledger.LedgerID,
 		Currency: "USD",
-		MetaData: map[string]interface{}{
+		MetaData: blnkgo.MetaData{
 			"customer_name": "SendWorldApp",
 		},
 	}

--- a/examples/escrow-application/main.go
+++ b/examples/escrow-application/main.go
@@ -30,7 +30,7 @@ func main() {
 	escrowBalanceBody := blnkgo.CreateLedgerBalanceRequest{
 		LedgerID: esrowLedger.LedgerID,
 		Currency: "USD",
-		MetaData: map[string]interface{}{
+		MetaData: blnkgo.MetaData{
 			"account_type":        "Escrow",
 			"customer_name":       "Alice Johnson",
 			"customer_id":         "CUST001",
@@ -49,7 +49,7 @@ func main() {
 	escrowBalanceBody2 := blnkgo.CreateLedgerBalanceRequest{
 		LedgerID: esrowLedger.LedgerID,
 		Currency: "USD",
-		MetaData: map[string]interface{}{
+		MetaData: blnkgo.MetaData{
 			"account_type":        "Escrow",
 			"customer_name":       "Bob Smith",
 			"customer_id":         "CUST002",
@@ -72,7 +72,7 @@ func main() {
 			Currency:    "USD",
 			Source:      "@bank-account",
 			Destination: escrowBalance.BalanceID,
-			MetaData: map[string]interface{}{
+			MetaData: blnkgo.MetaData{
 				"transaction_type": "deposit",
 				"customer_name":    "Alice Johnson",
 				"customer_id":      "alice-5786",
@@ -100,7 +100,7 @@ func main() {
 			Currency:    "USD",
 			Source:      escrowBalance.BalanceID,
 			Destination: escrowBalance2.BalanceID,
-			MetaData: map[string]interface{}{
+			MetaData: blnkgo.MetaData{
 				"transaction_type": "release",
 				"customer_name":    "Bob Smith",
 				"customer_id":      "bob-5786",
@@ -126,7 +126,7 @@ func main() {
 			Currency:    "USD",
 			Source:      escrowBalance2.BalanceID,
 			Destination: escrowBalance.BalanceID,
-			MetaData: map[string]interface{}{
+			MetaData: blnkgo.MetaData{
 				"transaction_type": "refund",
 				"customer_name":    "Alice Johnson",
 				"customer_id":      "alice-5786",

--- a/examples/virtual-card/main.go
+++ b/examples/virtual-card/main.go
@@ -16,7 +16,7 @@ func main() {
 
 	usdLedgerBody := blnkgo.CreateLedgerRequest{
 		Name: "USD Ledger",
-		MetaData: map[string]interface{}{
+		MetaData: blnkgo.MetaData{
 			"project_name": "USD virtual card",
 		},
 	}
@@ -30,7 +30,7 @@ func main() {
 	usdBalanceBody := blnkgo.CreateLedgerBalanceRequest{
 		LedgerID: usdLedger.LedgerID,
 		Currency: "USD",
-		MetaData: map[string]interface{}{
+		MetaData: blnkgo.MetaData{
 			"customer_name":        "Jerry",
 			"customer_internal_id": "1234",
 			"card_state":           "ACTIVE",
@@ -54,7 +54,7 @@ func main() {
 			Reference:   "ref-05",
 			Source:      "@World",
 			Destination: "@Merchant",
-			MetaData: map[string]interface{}{
+			MetaData: blnkgo.MetaData{
 				"merchant_name": "Store ABC",
 				"customer_name": "Jerry",
 			},
@@ -77,7 +77,7 @@ func main() {
 			Reference:   "ref-06",
 			Source:      "@Merchant",
 			Destination: usdBalance.BalanceID,
-			MetaData: map[string]interface{}{
+			MetaData: blnkgo.MetaData{
 				"merchant_name": "Store ABC",
 				"customer_name": "Jerry",
 			},

--- a/identity.go
+++ b/identity.go
@@ -26,7 +26,7 @@ type Identity struct {
 	State            string                 `json:"state"`
 	PostCode         string                 `json:"post_code"`
 	City             string                 `json:"city"`
-	MetaData         map[string]interface{} `json:"meta_data,omitempty"`
+	MetaData         MetaData     `json:"meta_data,omitempty"`
 }
 
 type IdentityResponse struct {

--- a/ledger.go
+++ b/ledger.go
@@ -12,12 +12,12 @@ type Ledger struct {
 	LedgerID  string                 `json:"ledger_id"`
 	Name      string                 `json:"name"`
 	CreatedAt time.Time              `json:"created_at"`
-	MetaData  map[string]interface{} `json:"meta_data,omitempty"`
+	MetaData  MetaData  `json:"meta_data,omitempty"`
 }
 
 type CreateLedgerRequest struct {
-	Name     string                 `json:"name"`
-	MetaData map[string]interface{} `json:"meta_data,omitempty"`
+	Name     string   `json:"name"`
+	MetaData MetaData `json:"meta_data,omitempty"`
 }
 
 type UpdateLedgerRequest struct {

--- a/ledger_balance.go
+++ b/ledger_balance.go
@@ -28,7 +28,7 @@ type LedgerBalance struct {
 	Currency              string                 `json:"currency"`
 	CreatedAt             time.Time              `json:"created_at"`
 	InflightExpiresAt     time.Time              `json:"inflight_expires_at"`
-	MetaData              map[string]interface{} `json:"meta_data,omitempty"`
+	MetaData              MetaData           `json:"meta_data,omitempty"`
 	TrackFundLineage      bool                   `json:"track_fund_lineage,omitempty"`
 	AllocationStrategy    AllocationStrategy     `json:"allocation_strategy,omitempty"`
 }
@@ -39,7 +39,7 @@ type CreateLedgerBalanceRequest struct {
 	Currency           string                 `json:"currency"`
 	TrackFundLineage   bool                   `json:"track_fund_lineage,omitempty"`
 	AllocationStrategy AllocationStrategy     `json:"allocation_strategy,omitempty"`
-	MetaData           map[string]interface{} `json:"meta_data,omitempty"`
+	MetaData           MetaData           `json:"meta_data,omitempty"`
 }
 
 // GetBalanceRequest holds optional query parameters for LedgerBalance.Get.

--- a/metadata.go
+++ b/metadata.go
@@ -6,7 +6,7 @@ import (
 )
 
 // MetaData is a flexible key-value metadata map attached to Blnk resources.
-type MetaData map[string]interface{}
+type MetaData = map[string]interface{}
 
 type MetadataService service
 

--- a/metadata.go
+++ b/metadata.go
@@ -5,14 +5,17 @@ import (
 	"net/http"
 )
 
+// MetaData is a flexible key-value metadata map attached to Blnk resources.
+type MetaData map[string]interface{}
+
 type MetadataService service
 
 type UpdateMetaDataRequest struct {
-	MetaData map[string]interface{} `json:"meta_data"`
+	MetaData MetaData `json:"meta_data"`
 }
 
 type Metadata struct {
-	MetaData map[string]interface{} `json:"metadata"`
+	MetaData MetaData `json:"metadata"`
 }
 
 func (s *MetadataService) UpdateMetadata(entityID string, body UpdateMetaDataRequest) (*Metadata, *http.Response, error) {

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -20,7 +20,7 @@ func TestTransactionService_UpdateMetadata(t *testing.T) {
 	tests := []struct {
 		name        string
 		entityID    string
-		metadata    map[string]interface{}
+		metadata    blnkgo.MetaData
 		expectError bool
 		errorMsg    string
 		statusCode  int
@@ -29,7 +29,7 @@ func TestTransactionService_UpdateMetadata(t *testing.T) {
 		{
 			name:     "successful metadata update",
 			entityID: "entity-123",
-			metadata: map[string]interface{}{
+			metadata: blnkgo.MetaData{
 				"key1": "value1",
 				"key2": 42,
 				"key3": true,
@@ -38,7 +38,7 @@ func TestTransactionService_UpdateMetadata(t *testing.T) {
 			statusCode:  http.StatusOK,
 			setupMocks: func(m *MockClient) {
 				expectedResponse := &blnkgo.UpdateMetaDataRequest{
-					MetaData: map[string]interface{}{
+					MetaData: blnkgo.MetaData{
 						"key1": "value1",
 						"key2": 42,
 						"key3": true,
@@ -61,7 +61,7 @@ func TestTransactionService_UpdateMetadata(t *testing.T) {
 		{
 			name:        "empty entity ID",
 			entityID:    "",
-			metadata:    map[string]interface{}{"key": "value"},
+			metadata:    blnkgo.MetaData{"key": "value"},
 			expectError: true,
 			errorMsg:    "entity ID is required",
 			setupMocks:  func(m *MockClient) {},
@@ -69,7 +69,7 @@ func TestTransactionService_UpdateMetadata(t *testing.T) {
 		{
 			name:        "request creation failure",
 			entityID:    "entity-123",
-			metadata:    map[string]interface{}{"key": "value"},
+			metadata:    blnkgo.MetaData{"key": "value"},
 			expectError: true,
 			errorMsg:    "failed to create request",
 			setupMocks: func(m *MockClient) {
@@ -80,7 +80,7 @@ func TestTransactionService_UpdateMetadata(t *testing.T) {
 		{
 			name:        "server error",
 			entityID:    "entity-123",
-			metadata:    map[string]interface{}{"key": "value"},
+			metadata:    blnkgo.MetaData{"key": "value"},
 			expectError: true,
 			errorMsg:    "server error",
 			statusCode:  http.StatusInternalServerError,
@@ -95,7 +95,7 @@ func TestTransactionService_UpdateMetadata(t *testing.T) {
 		{
 			name:        "entity not found",
 			entityID:    "nonexistent-123",
-			metadata:    map[string]interface{}{"key": "value"},
+			metadata:    blnkgo.MetaData{"key": "value"},
 			expectError: true,
 			errorMsg:    "entity not found",
 			statusCode:  http.StatusNotFound,

--- a/transaction.go
+++ b/transaction.go
@@ -32,7 +32,7 @@ type ParentTransaction struct {
 	SkipQueue     bool                   `json:"skip_queue"`
 	Atomic        bool                   `json:"atomic,omitempty"`
 	Status        PryTransactionStatus   `json:"status"`
-	MetaData      map[string]interface{} `json:"meta_data,omitempty"`
+	MetaData      MetaData             `json:"meta_data,omitempty"`
 	EffectiveDate *time.Time             `json:"effective_date"`
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -111,7 +111,7 @@ func TestUpdateTransaction(t *testing.T) {
 					Currency:    "USD",
 					Source:      "@bank-account",
 					Destination: "@World",
-					MetaData: map[string]interface{}{
+					MetaData: blnkgo.MetaData{
 						"transaction_type": "deposit",
 						"customer_name":    "Alice Johnson",
 						"customer_id":      "alice-5786",
@@ -271,7 +271,7 @@ func TestCreateTransactionSuccess(t *testing.T) {
 			Currency:    "USD",
 			Source:      "@bank-account",
 			Destination: "@World",
-			MetaData: map[string]interface{}{
+			MetaData: blnkgo.MetaData{
 				"transaction_type": "deposit",
 				"customer_name":    "Alice Johnson",
 				"customer_id":      "alice-5786",
@@ -908,7 +908,7 @@ func TestCreateTransactionWithInflightCommitDate(t *testing.T) {
 			Currency:    "USD",
 			Source:      "@bank-account",
 			Destination: "@World",
-			MetaData: map[string]interface{}{
+			MetaData: blnkgo.MetaData{
 				"transaction_type": "deposit",
 				"customer_name":    "Bob Smith",
 				"customer_id":      "bob-1234",
@@ -955,7 +955,7 @@ func TestCreateTransactionWithInflightExpiryAndCommitDate(t *testing.T) {
 			Currency:    "EUR",
 			Source:      "@escrow-account",
 			Destination: "@merchant",
-			MetaData: map[string]interface{}{
+			MetaData: blnkgo.MetaData{
 				"transaction_type": "escrow_release",
 				"order_id":         "order-9876",
 			},


### PR DESCRIPTION
## Summary
- Export `type MetaData map[string]interface{}` for flexible resource metadata
- Replace `map[string]interface{}` on `meta_data` fields across ledger, balance, identity, transaction, and metadata service structs
- Update README and examples to use `MetaData{...}`

Closes #132

## Notes
- Backward compatible type alias; existing map literals still work
- `search.SearchDocument.MetaData` stays `interface{}` (search hits can be string, map, or array)
- Follow-up: update Go SDK docs field tables to type `MetaData` after merge

## Test plan
- [x] `go test ./...`