### PR TITLE
Add LedgerBalance.List (GET /balances)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,23 @@ if err != nil {
 fmt.Printf("Balance Created: %+v\n", newBalance)
 ```
 
+### Listing Balances
+
+Retrieve balances with `GET /balances`. Core applies default pagination (`limit=10`, `offset=0`) when no query parameters are passed:
+
+```go
+balances, resp, err := client.LedgerBalance.List()
+if err != nil {
+    fmt.Printf("Error listing balances: %v\n", err)
+    return
+}
+
+fmt.Printf("Balances: %+v\n", balances)
+fmt.Printf("Status Code: %d\n", resp.StatusCode)
+```
+
+For structured queries, use `LedgerBalance.Filter` instead.
+
 To enable fund lineage tracking on create, set `track_fund_lineage` (requires `identity_id`) and optionally `allocation_strategy`:
 
 ```go

--- a/integration/README.md
+++ b/integration/README.md
@@ -29,6 +29,7 @@ go test -tags=integration -v ./integration/... -run Issue36
 go test -tags=integration -v ./integration/... -run Issue61
 go test -tags=integration -v ./integration/... -run Issue58
 go test -tags=integration -v ./integration/... -run Issue59
+go test -tags=integration -v ./integration/... -run Issue122
 
 # all integration tests
 go test -tags=integration -v ./integration/... 
@@ -78,5 +79,6 @@ go test -tags=integration -v ./integration/...
 | #117 delete identity | 0.15.0+ | DELETE /identities/{id} |
 | #118 delete balance monitor | 0.15.0+ | DELETE /balance-monitors/{id} |
 | #119 reconciliation run response | 0.15.0+ | POST /reconciliation/start returns reconciliation_id only |
+| #122 list balances | 0.14.x+ | GET /balances (default limit/offset) |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue122_test.go
+++ b/integration/issue122_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+// Integration tests for issue #122 — LedgerBalance.List (GET /balances).
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue122
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue122_ListBalances(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "Issue122 List " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	created, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, created.BalanceID)
+
+	balances, resp, err := client.LedgerBalance.List()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, balances)
+
+	found := false
+	for _, bal := range balances {
+		if bal.BalanceID == created.BalanceID {
+			found = true
+			require.Equal(t, ledger.LedgerID, bal.LedgerID)
+			require.Equal(t, "USD", bal.Currency)
+			break
+		}
+	}
+	// Core defaults GET /balances to limit=10. On a busy instance the new balance may
+	// fall outside that window; still require it when the window is not full.
+	if len(balances) < 10 {
+		require.True(t, found, "created balance should appear in default list window")
+	}
+}

--- a/ledger_balance.go
+++ b/ledger_balance.go
@@ -68,6 +68,23 @@ func (s *LedgerBalanceService) Create(body CreateLedgerBalanceRequest) (*LedgerB
 	return ledgerBalance, resp, nil
 }
 
+// List returns balances via GET /balances.
+// Core applies default pagination (limit=10, offset=0) when query params are omitted.
+func (s *LedgerBalanceService) List() ([]LedgerBalance, *http.Response, error) {
+	req, err := s.client.NewRequest("balances", http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var balances []LedgerBalance
+	resp, err := s.client.CallWithRetry(req, &balances)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return balances, resp, nil
+}
+
 func (s *LedgerBalanceService) Get(balanceID string, opts ...*GetBalanceRequest) (*LedgerBalance, *http.Response, error) {
 	if balanceID == "" {
 		return nil, nil, fmt.Errorf("invalid: id is required")

--- a/ledger_balance_test.go
+++ b/ledger_balance_test.go
@@ -371,6 +371,74 @@ func TestLedgerBalanceService_GetByIndicator(t *testing.T) {
 	}
 }
 
+func TestLedgerBalanceService_List_Success(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+
+	fixedTime := time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC)
+	expectedResponse := []blnkgo.LedgerBalance{
+		{
+			BalanceID: "balance123",
+			LedgerID:  "ledger123",
+			Currency:  "USD",
+			CreatedAt: fixedTime,
+		},
+		{
+			BalanceID: "balance456",
+			LedgerID:  "ledger456",
+			Currency:  "NGN",
+			CreatedAt: fixedTime,
+		},
+	}
+
+	mockClient.On("NewRequest", "balances", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		balances := args.Get(1).(*[]blnkgo.LedgerBalance)
+		*balances = expectedResponse
+	})
+
+	balances, resp, err := svc.List()
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, balances)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_List_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+
+	mockClient.On("NewRequest", "balances", http.MethodGet, nil).Return(nil, fmt.Errorf("failed to create request"))
+
+	balances, resp, err := svc.List()
+
+	assert.Error(t, err)
+	assert.Nil(t, balances)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to create request")
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_List_ServerError(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+
+	mockClient.On("NewRequest", "balances", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusInternalServerError,
+	}, fmt.Errorf("server error"))
+
+	balances, resp, err := svc.List()
+
+	assert.Error(t, err)
+	assert.Nil(t, balances)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(t, err.Error(), "server error")
+	mockClient.AssertExpectations(t)
+}
+
 func TestLedgerBalanceService_Filter_Success(t *testing.T) {
 	mockClient, svc := setupLedgerBalanceService()
 


### PR DESCRIPTION
## Summary
- Add `LedgerBalance.List()` calling `GET /balances` (Core default limit/offset)
- Unit tests for success, request failure, and server error paths
- Integration test + README / integration docs for issue #122

## Test plan
- [x] `go test ./... -run LedgerBalanceService_List`
- [x] `BLNK_API_KEY=... go test -tags=integration -v ./integration/... -run Issue122` against Core 0.15.0
- [ ] Reviewer: spot-check README Listing Balances example

Closes #122