### PR TITLE
Add Transaction.List (GET /transactions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,23 @@ if err != nil {
 fmt.Printf("Transaction Recorded: %+v\n", newTransaction)
 ```
 
+### Listing Transactions
+
+Retrieve transactions with `GET /transactions`. Core applies default pagination (`limit=20`, `offset=0`) when no query parameters are passed:
+
+```go
+transactions, resp, err := client.Transaction.List()
+if err != nil {
+    fmt.Printf("Error listing transactions: %v\n", err)
+    return
+}
+
+fmt.Printf("Transactions: %+v\n", transactions)
+fmt.Printf("Status Code: %d\n", resp.StatusCode)
+```
+
+For structured queries, use `Transaction.Filter` instead.
+
 ### Recording Bulk Transactions
 
 Submit multiple transactions in a single request (up to `MaxBulkCreateItems`, 10,000 per request). Set `Atomic` to ensure all transactions succeed or fail together:

--- a/integration/README.md
+++ b/integration/README.md
@@ -30,6 +30,7 @@ go test -tags=integration -v ./integration/... -run Issue61
 go test -tags=integration -v ./integration/... -run Issue58
 go test -tags=integration -v ./integration/... -run Issue59
 go test -tags=integration -v ./integration/... -run Issue122
+go test -tags=integration -v ./integration/... -run Issue123
 
 # all integration tests
 go test -tags=integration -v ./integration/... 
@@ -80,5 +81,6 @@ go test -tags=integration -v ./integration/...
 | #118 delete balance monitor | 0.15.0+ | DELETE /balance-monitors/{id} |
 | #119 reconciliation run response | 0.15.0+ | POST /reconciliation/start returns reconciliation_id only |
 | #122 list balances | 0.14.x+ | GET /balances (default limit/offset) |
+| #123 list transactions | 0.14.x+ | GET /transactions (default limit/offset) |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue123_test.go
+++ b/integration/issue123_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+
+// Integration tests for issue #123 — Transaction.List (GET /transactions).
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue123
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue123_ListTransactions(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	ref := "issue123-" + suffix
+
+	created, resp, err := client.Transaction.Create(blnkgo.CreateTransactionRequest{
+		ParentTransaction: blnkgo.ParentTransaction{
+			Amount:      100,
+			Reference:   ref,
+			Precision:   100,
+			Currency:    "USD",
+			Source:      "@FundingPool",
+			Destination: "@Issue123Dest",
+			Description: "Issue123 list transaction",
+			SkipQueue:   true,
+		},
+		AllowOverdraft: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, created.TransactionID)
+
+	transactions, resp, err := client.Transaction.List()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, transactions)
+
+	found := false
+	for _, txn := range transactions {
+		if txn.TransactionID == created.TransactionID {
+			found = true
+			require.Equal(t, ref, txn.Reference)
+			break
+		}
+	}
+	// Core defaults GET /transactions to limit=20. On a busy instance the new
+	// transaction may fall outside that window; still require it when not full.
+	if len(transactions) < 20 {
+		require.True(t, found, "created transaction should appear in default list window")
+	}
+}

--- a/transaction.go
+++ b/transaction.go
@@ -310,6 +310,23 @@ func (s *TransactionService) GetByReference(reference string) (*Transaction, *ht
 	return transaction, resp, nil
 }
 
+// List returns transactions via GET /transactions.
+// Core applies default pagination (limit=20, offset=0) when query params are omitted.
+func (s *TransactionService) List() ([]Transaction, *http.Response, error) {
+	req, err := s.client.NewRequest("transactions", http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var transactions []Transaction
+	resp, err := s.client.CallWithRetry(req, &transactions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return transactions, resp, nil
+}
+
 func (s *TransactionService) Filter(params FilterParams) (*FilterResponse, *http.Response, error) {
 	req, err := s.client.NewRequest("transactions/filter", http.MethodPost, params)
 	if err != nil {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -731,6 +731,80 @@ func TestTransactionService_Get(t *testing.T) {
 	}
 }
 
+func TestTransactionService_List_Success(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	fixedTime := time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC)
+	expectedResponse := []blnkgo.Transaction{
+		{
+			ParentTransaction: blnkgo.ParentTransaction{
+				Amount:   750,
+				Currency: "USD",
+				Status:   blnkgo.PryTransactionStatusApplied,
+			},
+			TransactionID: "txn_abc123",
+			CreatedAt:     fixedTime,
+		},
+		{
+			ParentTransaction: blnkgo.ParentTransaction{
+				Amount:   500,
+				Currency: "NGN",
+				Status:   blnkgo.PryTransactionStatusApplied,
+			},
+			TransactionID: "txn_def456",
+			CreatedAt:     fixedTime,
+		},
+	}
+
+	mockClient.On("NewRequest", "transactions", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		transactions := args.Get(1).(*[]blnkgo.Transaction)
+		*transactions = expectedResponse
+	})
+
+	transactions, resp, err := svc.List()
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, transactions)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_List_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	mockClient.On("NewRequest", "transactions", http.MethodGet, nil).Return(nil, fmt.Errorf("failed to create request"))
+
+	transactions, resp, err := svc.List()
+
+	assert.Error(t, err)
+	assert.Nil(t, transactions)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to create request")
+	mockClient.AssertExpectations(t)
+}
+
+func TestTransactionService_List_ServerError(t *testing.T) {
+	mockClient, svc := setupTransactionService()
+
+	mockClient.On("NewRequest", "transactions", http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusInternalServerError,
+	}, fmt.Errorf("server error"))
+
+	transactions, resp, err := svc.List()
+
+	assert.Error(t, err)
+	assert.Nil(t, transactions)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(t, err.Error(), "server error")
+	mockClient.AssertExpectations(t)
+}
+
 func TestTransactionService_Filter_Success(t *testing.T) {
 	mockClient, svc := setupTransactionService()
 


### PR DESCRIPTION
## Summary
- Add `Transaction.List()` calling `GET /transactions` (Core default limit=20, offset=0)
- Unit tests for success, request failure, and server error paths
- Integration test + README / integration docs for issue #123

## Test plan
- [x] `go test ./... -run TransactionService_List`
- [x] `BLNK_API_KEY=... go test -tags=integration -v ./integration/... -run Issue123` against Core 0.15.0
- [ ] Reviewer: spot-check README Listing Transactions example
- [ ] Optional: Postman Cloud `Blnk Go SDK — Local Core Tests` → `TEST — #123 List transactions` (local only, not in repo)

Closes #123