### PR TITLE
Add BalanceMonitor.ListByBalanceID

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,19 @@ if err != nil {
 fmt.Printf("Monitor Created: %+v\n", monitor)
 ```
 
+List monitors for a specific balance:
+
+```go
+monitors, resp, err := client.BalanceMonitor.ListByBalanceID(newBalance.BalanceID)
+if err != nil {
+    fmt.Printf("Error listing monitors: %v\n", err)
+    return
+}
+
+fmt.Printf("Monitors: %+v\n", monitors)
+fmt.Printf("Status Code: %d\n", resp.StatusCode)
+```
+
 Delete a balance monitor (Core 0.15.0+):
 
 ```go

--- a/balance_monitor.go
+++ b/balance_monitor.go
@@ -79,6 +79,28 @@ func (s *BalanceMonitorService) List() ([]MonitorDataResp, *http.Response, error
 	return monitorData, resp, nil
 }
 
+// ListByBalanceID returns monitors for a specific balance via
+// GET /balance-monitors/balances/{balance_id}.
+func (s *BalanceMonitorService) ListByBalanceID(balanceID string) ([]MonitorDataResp, *http.Response, error) {
+	if err := ValidateBalanceID(balanceID); err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("balance-monitors/balances/%s", balanceID)
+	req, err := s.client.NewRequest(u, http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var monitorData []MonitorDataResp
+	resp, err := s.client.CallWithRetry(req, &monitorData)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return monitorData, resp, nil
+}
+
 func (s *BalanceMonitorService) Update(monitorID string, data MonitorData) (*MonitorDataResp, *http.Response, error) {
 	req, err := s.client.NewRequest("balance-monitors/"+monitorID, http.MethodPut, data)
 	if err != nil {

--- a/balance_monitor_test.go
+++ b/balance_monitor_test.go
@@ -224,6 +224,77 @@ func TestBalanceMonitorService_List_ServerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "server error")
 	mockClient.AssertExpectations(t)
 }
+
+func TestBalanceMonitorService_ListByBalanceID_Success(t *testing.T) {
+	mockClient, svc := setupBalanceMonitorService()
+
+	balanceID := "balance-123"
+	expectedResp := []blnkgo.MonitorDataResp{
+		{
+			MonitorID:   "monitor-123",
+			CreatedAt:   time.Now().Format(time.RFC3339),
+			MonitorData: blnkgo.MonitorData{BalanceID: balanceID},
+		},
+	}
+
+	mockClient.On("NewRequest", "balance-monitors/balances/"+balanceID, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(args mock.Arguments) {
+		resp := args.Get(1).(*[]blnkgo.MonitorDataResp)
+		*resp = expectedResp
+	})
+
+	resp, httpResp, err := svc.ListByBalanceID(balanceID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	assert.Equal(t, expectedResp, resp)
+	mockClient.AssertExpectations(t)
+}
+
+func TestBalanceMonitorService_ListByBalanceID_EmptyBalanceID(t *testing.T) {
+	_, svc := setupBalanceMonitorService()
+
+	resp, httpResp, err := svc.ListByBalanceID("")
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "balance id is required")
+}
+
+func TestBalanceMonitorService_ListByBalanceID_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupBalanceMonitorService()
+
+	balanceID := "balance-123"
+	mockClient.On("NewRequest", "balance-monitors/balances/"+balanceID, http.MethodGet, nil).Return(nil, errors.New("failed to create request"))
+
+	resp, httpResp, err := svc.ListByBalanceID(balanceID)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, httpResp)
+	assert.Contains(t, err.Error(), "failed to create request")
+	mockClient.AssertExpectations(t)
+}
+
+func TestBalanceMonitorService_ListByBalanceID_ServerError(t *testing.T) {
+	mockClient, svc := setupBalanceMonitorService()
+
+	balanceID := "balance-123"
+	mockClient.On("NewRequest", "balance-monitors/balances/"+balanceID, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{StatusCode: http.StatusInternalServerError}, errors.New("server error"))
+
+	resp, httpResp, err := svc.ListByBalanceID(balanceID)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.NotNil(t, httpResp)
+	assert.Equal(t, http.StatusInternalServerError, httpResp.StatusCode)
+	assert.Contains(t, err.Error(), "server error")
+	mockClient.AssertExpectations(t)
+}
+
 func TestBalanceMonitorService_Update_Success(t *testing.T) {
 	mockClient, svc := setupBalanceMonitorService()
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -31,6 +31,7 @@ go test -tags=integration -v ./integration/... -run Issue58
 go test -tags=integration -v ./integration/... -run Issue59
 go test -tags=integration -v ./integration/... -run Issue122
 go test -tags=integration -v ./integration/... -run Issue123
+go test -tags=integration -v ./integration/... -run Issue124
 
 # all integration tests
 go test -tags=integration -v ./integration/... 
@@ -82,5 +83,6 @@ go test -tags=integration -v ./integration/...
 | #119 reconciliation run response | 0.15.0+ | POST /reconciliation/start returns reconciliation_id only |
 | #122 list balances | 0.14.x+ | GET /balances (default limit/offset) |
 | #123 list transactions | 0.14.x+ | GET /transactions (default limit/offset) |
+| #124 list monitors by balance | 0.14.x+ | GET /balance-monitors/balances/{balance_id} |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue124_test.go
+++ b/integration/issue124_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+// Integration tests for issue #124 — BalanceMonitor.ListByBalanceID
+// (GET /balance-monitors/balances/{balance_id}).
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue124
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue124_ListByBalanceID(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{
+		Name: "Issue124 ListByBalance " + suffix,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	balance, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	created, resp, err := client.BalanceMonitor.Create(blnkgo.MonitorData{
+		BalanceID: balance.BalanceID,
+		Condition: blnkgo.MonitorCondition{
+			Field:     "credit_balance",
+			Operator:  blnkgo.OperatorGreaterThan,
+			Value:     1000,
+			Precision: 100,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, created.MonitorID)
+
+	monitors, resp, err := client.BalanceMonitor.ListByBalanceID(balance.BalanceID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, monitors)
+
+	found := false
+	for _, mon := range monitors {
+		if mon.MonitorID == created.MonitorID {
+			found = true
+			require.Equal(t, balance.BalanceID, mon.BalanceID)
+			break
+		}
+	}
+	require.True(t, found, "created monitor should be returned for its balance")
+}
+
+func TestIssue124_ListByBalanceID_EmptyBalanceID(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.BalanceMonitor.ListByBalanceID("")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "balance id is required")
+}

--- a/validate_balance_monitor.go
+++ b/validate_balance_monitor.go
@@ -12,3 +12,11 @@ func ValidateMonitorID(monitorID string) error {
 	}
 	return nil
 }
+
+// ValidateBalanceID performs client-side checks before operations that require a balance ID.
+func ValidateBalanceID(balanceID string) error {
+	if strings.TrimSpace(balanceID) == "" {
+		return fmt.Errorf("balance id is required")
+	}
+	return nil
+}

--- a/validate_balance_monitor_test.go
+++ b/validate_balance_monitor_test.go
@@ -12,3 +12,9 @@ func TestValidateMonitorID(t *testing.T) {
 	require.Error(t, blnkgo.ValidateMonitorID(""))
 	require.Error(t, blnkgo.ValidateMonitorID("   "))
 }
+
+func TestValidateBalanceID(t *testing.T) {
+	require.NoError(t, blnkgo.ValidateBalanceID("bln_test_123"))
+	require.Error(t, blnkgo.ValidateBalanceID(""))
+	require.Error(t, blnkgo.ValidateBalanceID("   "))
+}


### PR DESCRIPTION
## Summary
- Add `BalanceMonitor.ListByBalanceID(balanceID)` calling `GET /balance-monitors/balances/{balance_id}`
- Client-side validation via `ValidateBalanceID` (non-empty)
- Unit + integration tests and README example

## Test plan
- [x] `go test ./... -run 'ListByBalanceID|ValidateBalanceID'`
- [x] `BLNK_API_KEY=... go test -tags=integration -v ./integration/... -run Issue124` against Core 0.15.0
- [ ] Reviewer: spot-check README ListByBalanceID example
- [ ] Optional: Postman Cloud `Blnk Go SDK — Local Core Tests` → `TEST — #124 List monitors by balance` (local only, not in repo)

Closes #124