### PR TITLE
Add Search.MultiSearch (POST /multi-search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,23 @@ balances, resp, err := client.Search.SearchBalances(searchParams)
 ledgers, resp, err := client.Search.SearchLedgers(searchParams)
 ```
 
+Search across multiple collections in one request:
+
+```go
+multi, resp, err := client.Search.MultiSearch(blnkgo.MultiSearchRequest{
+    Searches: []blnkgo.MultiSearchCollectionParams{
+        {Collection: "ledgers", Q: "General", QueryBy: "name", PerPage: 5},
+        {Collection: "balances", Q: "*", QueryBy: "currency", PerPage: 5},
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+for i, result := range multi.Results {
+    fmt.Printf("search[%d] found=%d\n", i, result.Found)
+}
+```
+
 Start a Typesense reindex and poll progress:
 
 ```go

--- a/integration/README.md
+++ b/integration/README.md
@@ -32,6 +32,7 @@ go test -tags=integration -v ./integration/... -run Issue59
 go test -tags=integration -v ./integration/... -run Issue122
 go test -tags=integration -v ./integration/... -run Issue123
 go test -tags=integration -v ./integration/... -run Issue124
+go test -tags=integration -v ./integration/... -run Issue125
 
 # all integration tests
 go test -tags=integration -v ./integration/... 
@@ -84,5 +85,6 @@ go test -tags=integration -v ./integration/...
 | #122 list balances | 0.14.x+ | GET /balances (default limit/offset) |
 | #123 list transactions | 0.14.x+ | GET /transactions (default limit/offset) |
 | #124 list monitors by balance | 0.14.x+ | GET /balance-monitors/balances/{balance_id} |
+| #125 multi-search | 0.14.x+ | POST /multi-search |
 
 If `BLNK_API_KEY` is unset, integration tests skip.

--- a/integration/issue125_test.go
+++ b/integration/issue125_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+// Integration tests for issue #125 — Search.MultiSearch (POST /multi-search).
+// Requires Blnk Core running at http://localhost:5001 with Typesense available,
+// and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue125
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue125_MultiSearch(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	ledgerName := "Issue125 MultiSearch " + suffix
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: ledgerName})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotEmpty(t, ledger.LedgerID)
+
+	deadline := time.Now().Add(30 * time.Second)
+	var multiResp *blnkgo.MultiSearchResponse
+	for {
+		multiResp, resp, err = client.Search.MultiSearch(blnkgo.MultiSearchRequest{
+			Searches: []blnkgo.MultiSearchCollectionParams{
+				{
+					Collection: "ledgers",
+					Q:          ledgerName,
+					QueryBy:    "name",
+					PerPage:    5,
+				},
+				{
+					Collection: "balances",
+					Q:          "*",
+					QueryBy:    "currency",
+					PerPage:    1,
+				},
+			},
+		})
+		if err == nil && resp.StatusCode == http.StatusOK && len(multiResp.Results) == 2 && multiResp.Results[0].Found > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "multi-search timed out waiting for index")
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Len(t, multiResp.Results, 2)
+			require.Greater(t, multiResp.Results[0].Found, 0, "expected indexed ledger in multi-search results")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, multiResp.Results, 2)
+	require.Greater(t, multiResp.Results[0].Found, 0)
+	require.GreaterOrEqual(t, multiResp.Results[1].Found, 0)
+}
+
+func TestIssue125_MultiSearch_EmptySearches(t *testing.T) {
+	client := newIntegrationClient(t)
+
+	_, resp, err := client.Search.MultiSearch(blnkgo.MultiSearchRequest{})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "searches cannot be empty")
+}

--- a/search.go
+++ b/search.go
@@ -135,6 +135,27 @@ type SearchDocument struct {
 	Name string `json:"name,omitempty"`
 }
 
+// MultiSearchCollectionParams is one search in a POST /multi-search request.
+type MultiSearchCollectionParams struct {
+	Collection string `json:"collection"`
+	Q          string `json:"q"`
+	QueryBy    string `json:"query_by,omitempty"`
+	FilterBy   string `json:"filter_by,omitempty"`
+	SortBy     string `json:"sort_by,omitempty"`
+	Page       int    `json:"page,omitempty"`
+	PerPage    int    `json:"per_page,omitempty"`
+}
+
+// MultiSearchRequest is the body for POST /multi-search.
+type MultiSearchRequest struct {
+	Searches []MultiSearchCollectionParams `json:"searches"`
+}
+
+// MultiSearchResponse is returned by POST /multi-search.
+type MultiSearchResponse struct {
+	Results []SearchResponse `json:"results"`
+}
+
 // StartReindexRequest is the optional body for POST /search/reindex.
 type StartReindexRequest struct {
 	BatchSize *int `json:"batch_size,omitempty"`
@@ -171,6 +192,34 @@ func (s *SearchService) SearchDocument(body SearchParams, resource ResourceType)
 	}
 
 	return searchResponse, resp, nil
+}
+
+// MultiSearch runs searches across one or more Typesense collections via POST /multi-search.
+func (s *SearchService) MultiSearch(body MultiSearchRequest) (*MultiSearchResponse, *http.Response, error) {
+	if len(body.Searches) == 0 {
+		return nil, nil, fmt.Errorf("searches cannot be empty")
+	}
+	for i, search := range body.Searches {
+		if search.Collection == "" {
+			return nil, nil, fmt.Errorf("searches[%d].collection is required", i)
+		}
+		if search.Q == "" {
+			return nil, nil, fmt.Errorf("searches[%d].q is required", i)
+		}
+	}
+
+	req, err := s.client.NewRequest("multi-search", http.MethodPost, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	multiResp := new(MultiSearchResponse)
+	resp, err := s.client.CallWithRetry(req, multiResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return multiResp, resp, nil
 }
 
 // StartReindex triggers a full Typesense reindex from the database.

--- a/search_test.go
+++ b/search_test.go
@@ -112,6 +112,121 @@ func TestSearchService_SearchDocument_IdentitiesResource(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestSearchService_MultiSearch_Success(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	body := blnkgo.MultiSearchRequest{
+		Searches: []blnkgo.MultiSearchCollectionParams{
+			{Collection: "ledgers", Q: "General", QueryBy: "name", PerPage: 1},
+			{Collection: "balances", Q: "*", QueryBy: "currency", PerPage: 1},
+		},
+	}
+
+	expectedResponse := &blnkgo.MultiSearchResponse{
+		Results: []blnkgo.SearchResponse{
+			{Found: 1, OutOf: 10, Page: 1, SearchTimeMs: 2},
+			{Found: 5, OutOf: 20, Page: 1, SearchTimeMs: 3},
+		},
+	}
+
+	mockClient.On("NewRequest", "multi-search", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil).Run(func(args mock.Arguments) {
+		result := args.Get(1).(*blnkgo.MultiSearchResponse)
+		*result = *expectedResponse
+	})
+
+	result, resp, err := svc.MultiSearch(body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, result)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
+func TestSearchService_MultiSearch_EmptySearches(t *testing.T) {
+	_, svc := setupSearchService()
+
+	_, resp, err := svc.MultiSearch(blnkgo.MultiSearchRequest{})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "searches cannot be empty")
+}
+
+func TestSearchService_MultiSearch_MissingCollection(t *testing.T) {
+	_, svc := setupSearchService()
+
+	_, resp, err := svc.MultiSearch(blnkgo.MultiSearchRequest{
+		Searches: []blnkgo.MultiSearchCollectionParams{
+			{Q: "*"},
+		},
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "collection is required")
+}
+
+func TestSearchService_MultiSearch_MissingQ(t *testing.T) {
+	_, svc := setupSearchService()
+
+	_, resp, err := svc.MultiSearch(blnkgo.MultiSearchRequest{
+		Searches: []blnkgo.MultiSearchCollectionParams{
+			{Collection: "ledgers"},
+		},
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "q is required")
+}
+
+func TestSearchService_MultiSearch_RequestCreationFailure(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	body := blnkgo.MultiSearchRequest{
+		Searches: []blnkgo.MultiSearchCollectionParams{
+			{Collection: "ledgers", Q: "*"},
+		},
+	}
+
+	mockClient.On("NewRequest", "multi-search", http.MethodPost, body).Return(nil, fmt.Errorf("failed to create request"))
+
+	result, resp, err := svc.MultiSearch(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to create request")
+	mockClient.AssertExpectations(t)
+}
+
+func TestSearchService_MultiSearch_ServerError(t *testing.T) {
+	mockClient, svc := setupSearchService()
+
+	body := blnkgo.MultiSearchRequest{
+		Searches: []blnkgo.MultiSearchCollectionParams{
+			{Collection: "ledgers", Q: "*"},
+		},
+	}
+
+	mockClient.On("NewRequest", "multi-search", http.MethodPost, body).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusBadRequest,
+	}, fmt.Errorf("search error"))
+
+	result, resp, err := svc.MultiSearch(body)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	mockClient.AssertExpectations(t)
+}
+
 func TestSearchService_SearchDocument_EmptyRequest(t *testing.T) {
 	mockClient, svc := setupSearchService()
 	body := blnkgo.SearchParams{}


### PR DESCRIPTION
## Summary
- Add `Search.MultiSearch` calling `POST /multi-search` with `MultiSearchRequest` / `MultiSearchResponse` types
- Client-side validation for empty searches and required `collection` / `q` fields
- Unit + integration tests and README example

## Test plan
- [x] `go test ./... -run MultiSearch`
- [x] `BLNK_API_KEY=... go test -tags=integration -v ./integration/... -run Issue125` against Core 0.15.0
- [ ] Reviewer: spot-check README MultiSearch example
- [ ] Optional: Postman Cloud `Blnk Go SDK — Local Core Tests` → `TEST — #125 MultiSearch` (local only, not in repo)

Closes #125