### PR TITLE
Document Ledger.List in README (closes #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,23 @@ if err != nil {
 fmt.Printf("Ledger Updated: %+v\n", updatedLedger)
 ```
 
+### Listing Ledgers
+
+Retrieve ledgers with `GET /ledgers`. Core applies default pagination (`limit=10`, `offset=0`) when no query parameters are passed:
+
+```go
+ledgers, resp, err := client.Ledger.List()
+if err != nil {
+    fmt.Printf("Error listing ledgers: %v\n", err)
+    return
+}
+
+fmt.Printf("Ledgers: %+v\n", ledgers)
+fmt.Printf("Status Code: %d\n", resp.StatusCode)
+```
+
+For structured queries, use `Ledger.Filter` instead.
+
 ---
 
 ## 5. Creating Balances


### PR DESCRIPTION
## Summary
- Documents `client.Ledger.List()` → `GET /ledgers` in the Go SDK README, including Core’s default pagination (`limit=10`).
- Closes the README half of [#75](https://github.com/blnkfinance/blnk-go/issues/75); Go SDK method page ships in a paired `blnk-docs` PR.
- Core API reference `list-ledger` page intentionally deferred to a follow-up.

## Test plan
- [ ] Skim README “Listing Ledgers” section for accuracy against `Ledger.List`
- [ ] Confirm link/context next to Updating a Ledger / Creating Balances still reads cleanly