### PR TITLE
feat: add with_queued to LedgerBalance.Get

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,20 +279,24 @@ balanceBody := blnkgo.CreateLedgerBalanceRequest{
 lineageBalance, resp, err := client.LedgerBalance.Create(balanceBody)
 ```
 
-### Retrieving a Balance (from source)
+### Retrieving a Balance
 
-By default, `Get` returns the stored balance snapshot. Pass `from_source: true` to reconstruct the balance from all transactions instead:
+By default, `Get` returns the stored balance snapshot. Optional query parameters:
+
+- `from_source: true` — reconstruct the balance from all transactions instead of snapshots
+- `with_queued: true` — include queued debit/credit balances in the response
 
 ```go
 balance, resp, err := client.LedgerBalance.Get(newBalance.BalanceID, &blnkgo.GetBalanceRequest{
     FromSource: true,
+    WithQueued: true,
 })
 if err != nil {
-    fmt.Printf("Error fetching balance from source: %v\n", err)
+    fmt.Printf("Error fetching balance: %v\n", err)
     return
 }
 
-fmt.Printf("Balance from source: %+v\n", balance)
+fmt.Printf("Balance: %+v\n", balance)
 ```
 
 Existing callers can keep using `client.LedgerBalance.Get(balanceID)` with no second argument.

--- a/integration/README.md
+++ b/integration/README.md
@@ -15,6 +15,7 @@ export BLNK_API_KEY=your_master_or_api_key
 go test -tags=integration -v ./integration/... -run Issue70
 go test -tags=integration -v ./integration/... -run Issue86
 go test -tags=integration -v ./integration/... -run Issue69
+go test -tags=integration -v ./integration/... -run Issue127
 go test -tags=integration -v ./integration/... -run Issue68
 go test -tags=integration -v ./integration/... -run Issue71
 go test -tags=integration -v ./integration/... -run Issue40
@@ -55,6 +56,7 @@ go test -tags=integration -v ./integration/...
 | #71 precise_distribution | 0.14.x+ | Split legs with precise_distribution on POST /transactions |
 | #86 update skip_queue | 0.14.x+ | skip_queue on inflight commit/void (Update + bulk) |
 | #69 balance from_source | 0.14.x+ | GET /balances/{id}?from_source=true |
+| #127 balance with_queued | 0.14.x+ | GET /balances/{id}?with_queued=true |
 | #68 balance lineage create | 0.14.x+ | track_fund_lineage + allocation_strategy on POST /balances |
 | #73 search identities | 0.14.x+ | Not 0.15-only |
 | #72 identity optional id | 0.14.x+ | Caller-supplied identity_id on POST /identities |

--- a/integration/issue127_test.go
+++ b/integration/issue127_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+// Integration tests for LedgerBalance.Get with_queued query param.
+// Requires Blnk Core running at http://localhost:5001 and BLNK_API_KEY in the environment.
+//
+// Run:
+//
+//	export BLNK_API_KEY=your_key
+//	go test -tags=integration -v ./integration/... -run Issue127
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	blnkgo "github.com/blnkfinance/blnk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue127_GetBalance_WithQueued(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "WithQueued " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	bal, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	withQueued, resp, err := client.LedgerBalance.Get(bal.BalanceID, &blnkgo.GetBalanceRequest{WithQueued: true})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, bal.BalanceID, withQueued.BalanceID)
+}
+
+func TestIssue127_GetBalance_WithFromSourceAndWithQueued(t *testing.T) {
+	client := newIntegrationClient(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ledger, resp, err := client.Ledger.Create(blnkgo.CreateLedgerRequest{Name: "WithQueuedCombo " + suffix})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	bal, resp, err := client.LedgerBalance.Create(blnkgo.CreateLedgerBalanceRequest{
+		LedgerID: ledger.LedgerID,
+		Currency: "USD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	got, resp, err := client.LedgerBalance.Get(bal.BalanceID, &blnkgo.GetBalanceRequest{
+		FromSource: true,
+		WithQueued: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, bal.BalanceID, got.BalanceID)
+}

--- a/ledger_balance.go
+++ b/ledger_balance.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -48,6 +49,8 @@ type CreateLedgerBalanceRequest struct {
 type GetBalanceRequest struct {
 	// FromSource reconstructs the balance from transactions instead of snapshots.
 	FromSource bool `json:"from_source,omitempty"`
+	// WithQueued includes queued debit/credit balances in the response.
+	WithQueued bool `json:"with_queued,omitempty"`
 }
 
 func (s *LedgerBalanceService) Create(body CreateLedgerBalanceRequest) (*LedgerBalance, *http.Response, error) {
@@ -95,8 +98,17 @@ func (s *LedgerBalanceService) Get(balanceID string, opts ...*GetBalanceRequest)
 		return nil, nil, fmt.Errorf("Get accepts at most one optional request")
 	}
 	u := fmt.Sprintf("balances/%s", balanceID)
-	if len(opts) > 0 && opts[0] != nil && opts[0].FromSource {
-		u += "?from_source=true"
+	if len(opts) > 0 && opts[0] != nil {
+		var params []string
+		if opts[0].FromSource {
+			params = append(params, "from_source=true")
+		}
+		if opts[0].WithQueued {
+			params = append(params, "with_queued=true")
+		}
+		if len(params) > 0 {
+			u += "?" + strings.Join(params, "&")
+		}
 	}
 	req, err := s.client.NewRequest(u, http.MethodGet, nil)
 	if err != nil {

--- a/ledger_balance_test.go
+++ b/ledger_balance_test.go
@@ -223,6 +223,42 @@ func TestLedgerBalanceService_Get_WithFromSource(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestLedgerBalanceService_Get_WithQueued(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "balance123"
+	expectedEndpoint := fmt.Sprintf("balances/%s?with_queued=true", balanceID)
+
+	mockClient.On("NewRequest", expectedEndpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, resp, err := svc.Get(balanceID, &blnkgo.GetBalanceRequest{WithQueued: true})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	mockClient.AssertCalled(t, "NewRequest", expectedEndpoint, http.MethodGet, nil)
+	mockClient.AssertExpectations(t)
+}
+
+func TestLedgerBalanceService_Get_WithFromSourceAndWithQueued(t *testing.T) {
+	mockClient, svc := setupLedgerBalanceService()
+	balanceID := "balance123"
+	expectedEndpoint := fmt.Sprintf("balances/%s?from_source=true&with_queued=true", balanceID)
+
+	mockClient.On("NewRequest", expectedEndpoint, http.MethodGet, nil).Return(&http.Request{}, nil)
+	mockClient.On("CallWithRetry", mock.Anything, mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	_, resp, err := svc.Get(balanceID, &blnkgo.GetBalanceRequest{FromSource: true, WithQueued: true})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	mockClient.AssertCalled(t, "NewRequest", expectedEndpoint, http.MethodGet, nil)
+	mockClient.AssertExpectations(t)
+}
+
 func TestLedgerBalanceService_Get_BackwardCompatibleNoOptions(t *testing.T) {
 	mockClient, svc := setupLedgerBalanceService()
 	balanceID := "balance123"


### PR DESCRIPTION
## Summary
- Add `WithQueued` to `GetBalanceRequest` for `GET /balances/{id}?with_queued=true`
- Refactor `LedgerBalance.Get` query building so `from_source` and `with_queued` combine with `&`
- Add unit tests for `with_queued` alone, `from_source` alone (existing), and both combined
- Add integration tests (Issue127) and README updates

## Test plan
- [x] `go test -run 'LedgerBalanceService_Get' -count=1 -v ./...`
- [ ] `go test -tags=integration -v ./integration/... -run Issue127` (requires local Blnk Core)